### PR TITLE
a componentView should per default contain itself and all of its components

### DIFF
--- a/structurizr-core/src/com/structurizr/view/ComponentView.java
+++ b/structurizr-core/src/com/structurizr/view/ComponentView.java
@@ -3,7 +3,6 @@ package com.structurizr.view;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.structurizr.model.Component;
 import com.structurizr.model.Container;
-import com.structurizr.model.SoftwareSystem;
 
 import java.util.Collection;
 
@@ -104,7 +103,8 @@ public class ComponentView extends View {
         addAllPeople();
         addAllContainers();
         addAllComponents();
-        removeElementsThatCantBeReachedFrom(this.container);
-    }
 
+        // Components of the current container should always be included in the ComponentView
+        removeElementsThatCantBeReachedFrom(this.container, this.container.getComponents());
+    }
 }

--- a/structurizr-core/src/com/structurizr/view/View.java
+++ b/structurizr-core/src/com/structurizr/view/View.java
@@ -85,7 +85,7 @@ public abstract class View implements Comparable<View> {
     /**
      * Adds the given software system to this view.
      *
-     * @param softwareSystem        the SoftwareSystem to add
+     * @param softwareSystem the SoftwareSystem to add
      */
     public void addSoftwareSystem(SoftwareSystem softwareSystem) {
         addElement(softwareSystem);
@@ -101,7 +101,7 @@ public abstract class View implements Comparable<View> {
     /**
      * Adds the given person to this view.
      *
-     * @param person        the Person to add
+     * @param person the Person to add
      */
     public void addPerson(Person person) {
         addElement(person);
@@ -121,7 +121,7 @@ public abstract class View implements Comparable<View> {
     /**
      * Gets the set of elements in this view.
      *
-     * @return  a Set of ElementView objects
+     * @return a Set of ElementView objects
      */
     public Set<ElementView> getElements() {
         return elementViews;
@@ -173,11 +173,17 @@ public abstract class View implements Comparable<View> {
         elementViews.removeIf(ev -> !elementIds.contains(ev.getId()));
     }
 
-    public void removeElementsThatCantBeReachedFrom(Element element) {
+    /**
+     * Removes all elements of a view that cannot be reached from a certain element
+     *
+     * @param element   the source element
+     * @param whiteList a set of elements that must not be removed
+     */
+    public void removeElementsThatCantBeReachedFrom(Element element, Set<? extends Element> whiteList) {
         Set<String> elementIdsToShow = new HashSet<>();
         findElementsToShow(element, elementIdsToShow, 1);
 
-        elementViews.removeIf(ev -> !elementIdsToShow.contains(ev.getId()));
+        elementViews.removeIf(ev -> !elementIdsToShow.contains(ev.getId()) && !whiteList.contains(ev.getElement()));
     }
 
     private void findElementsToShow(Element element, Set<String> elementIds, int depth) {

--- a/structurizr-core/src/com/structurizr/view/ViewSet.java
+++ b/structurizr-core/src/com/structurizr/view/ViewSet.java
@@ -65,6 +65,7 @@ public class ViewSet {
 
     public ComponentView createComponentView(Container container, String description) {
         ComponentView view = new ComponentView(container, description);
+        view.add(container);
         componentViews.add(view);
 
         return view;

--- a/structurizr-core/test/unit/com/structurizr/view/ViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ViewTests.java
@@ -235,4 +235,20 @@ public class ViewTests extends AbstractWorkspaceTestBase {
         assertEquals("The System - System Context [Some description]", systemContextView.getTitle());
     }
 
+    @Test
+    public void test_containerViewContainsItself() {
+        SoftwareSystem softwareSystem = model.addSoftwareSystem(Location.Internal, "The System", "Description");
+        Container container = softwareSystem.addContainer("Container", "", "");
+        Component component = container.addComponent("Component", "");
+
+        ViewSet views = workspace.getViews();
+        ComponentView componentView = views.createComponentView(container);
+        componentView.add(container);
+        componentView.addAllElements();
+
+        assertEquals(2, componentView.getElements().size());
+        assertTrue(componentView.getElements().contains(new ElementView(component)));
+        assertTrue(componentView.getElements().contains(new ElementView(container)));
+    }
+
 }

--- a/structurizr-core/test/unit/com/structurizr/view/ViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ViewTests.java
@@ -243,7 +243,6 @@ public class ViewTests extends AbstractWorkspaceTestBase {
 
         ViewSet views = workspace.getViews();
         ComponentView componentView = views.createComponentView(container);
-        componentView.add(container);
         componentView.addAllElements();
 
         assertEquals(2, componentView.getElements().size());


### PR DESCRIPTION
I'm not fully sure if that matches your expectations, but when creating a componentView for one of my models, I was kind of surprised that after calling `views.createComponentView(container)` the container itself is not included in the ComponentView. Could it ever make sense to create a ComponentView for a Container and not including the container itself?

Therefore I added `view.add(container);` in `viewSet.createComponentView`.

Second point was that when calling `componentView.addAllElements()` all the components of the given container where not included. That is because obviously there is no Relationship between component and container, that is just a plain parent-child relationship. But imho when I'm saying that I want to have a component view of a certain container, then I want to see all of those components in that container.

I therefore introduced a whitelist in the method `removeElementsThatCantBeReachedFrom`, letting the ComponentView pass the components of its containers.

Does that make sense to you?



