### PR TITLE
addComponentsAndDirectDependencies

### DIFF
--- a/structurizr-core/build.gradle
+++ b/structurizr-core/build.gradle
@@ -15,4 +15,5 @@ dependencies {
     compile files("${System.getProperty('java.home')}/../lib/tools.jar")
 
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:3.4.0'
 }

--- a/structurizr-core/src/com/structurizr/view/ComponentView.java
+++ b/structurizr-core/src/com/structurizr/view/ComponentView.java
@@ -142,40 +142,26 @@ public class ComponentView extends StaticView {
      * removed from the view though.
      * </p>
      */
-    public void addAllComponentsAndDirectDependencies() {
+    public void addDirectDependencies() {
         final Set<Element> insideElements = new HashSet<>();
         insideElements.add(getContainer());
-        insideElements.addAll(getContainer().getComponents());
-
-        addAllComponents();
+        getElements().stream().forEach(e -> insideElements.add(e.getElement()));
 
         // add relationships of all other elements to or from our inside components
         for (Relationship relationship : getContainer().getModel().getRelationships()) {
             if (insideElements.contains(relationship.getSource())) {
-                addElement(relationship.getDestination());
+                addElement(relationship.getDestination(), true);
             }
             if (insideElements.contains(relationship.getDestination())) {
-                addElement(relationship.getSource());
+                addElement(relationship.getSource(), true);
             }
         }
 
-        // remove all relationships between outside components, we dont care about them here
+        // remove all relationships between outside components, we don't care about them here
         getRelationships().stream()
-                .map(v -> v.getRelationship())
+                .map(RelationshipView::getRelationship)
                 .filter(r -> !insideElements.contains(r.getSource()) && !insideElements.contains(r.getDestination()))
-                .forEach(r -> remove(r));
-    }
-
-    private void addElement(Element element) {
-        if (element instanceof Person) {
-            add((Person) element);
-        } else if (element instanceof SoftwareSystem) {
-            add((SoftwareSystem) element);
-        } else if (element instanceof Component) {
-            add((Component) element);
-        } else if (element instanceof Container) {
-            add((Container) element);
-        }
+                .forEach(this::remove);
     }
 
 }

--- a/structurizr-core/src/com/structurizr/view/ComponentView.java
+++ b/structurizr-core/src/com/structurizr/view/ComponentView.java
@@ -85,7 +85,9 @@ public class ComponentView extends StaticView {
      * @param component the Component to add
      */
     public void add(Component component) {
-        addElement(component, true);
+        if (component != null && component.getContainer().equals(getContainer())) {
+            addElement(component, true);
+        }
     }
 
     /**
@@ -151,10 +153,10 @@ public class ComponentView extends StaticView {
         // add relationships of all other elements to or from our inside components
         for (Relationship relationship : getContainer().getModel().getRelationships()) {
             if (insideElements.contains(relationship.getSource())) {
-                addElement(relationship.getDestination(), true);
+                addElement(relationship.getDestination());
             }
             if (insideElements.contains(relationship.getDestination())) {
-                addElement(relationship.getSource(), true);
+                addElement(relationship.getSource());
             }
         }
 
@@ -163,6 +165,24 @@ public class ComponentView extends StaticView {
                 .map(RelationshipView::getRelationship)
                 .filter(r -> !insideElements.contains(r.getSource()) && !insideElements.contains(r.getDestination()))
                 .forEach(this::remove);
+    }
+
+    /**
+     * bit ugly code here but we want to ensure that {@link #addDirectDependencies()} calls the add methods
+     * directly in this class to not bypass any special handling here (i.e. don't add components of other containers)
+     *
+     * @param element the element to be added
+     */
+    private void addElement(Element element) {
+        if (element instanceof Person) {
+            add((Person) element);
+        } else if (element instanceof SoftwareSystem) {
+            add((SoftwareSystem) element);
+        } else if (element instanceof Component) {
+            add((Component) element);
+        } else if (element instanceof Container) {
+            add((Container) element);
+        }
     }
 
 }

--- a/structurizr-core/src/com/structurizr/view/ComponentView.java
+++ b/structurizr-core/src/com/structurizr/view/ComponentView.java
@@ -132,15 +132,16 @@ public class ComponentView extends StaticView {
      * component and all ingoing and outgoing relationships. Effectively, the following components
      * and relationships are added to the view:</p>
      * <ul>
-     * <li>all {@link Component}s of this view's {@link Container}</li>
      * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that have direct {@link Relationship}s to
-     * this Container or to one of its Components</li>
-     * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that are referenced by this
-     * {@link Container} or one of its {@link Component}s</li>
+     * this elements in this view including the Container itself</li>
+     * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that are referenced by the
+     * {@link Container} of this view or one of the {@link Element}s in this view</li>
      * </ul>
      * <p>{@link Relationship}s between external {@link Element}s (i.e. elements that are not part of this container) are
      * removed from the view though.
      * </p>
+     * <p>Dont forget to add elements to your view prior to calling this method, e.g. by calling {@link #addAllComponents()}
+     * or be selectively choosing certain components.</p>
      */
     public void addDirectDependencies() {
         final Set<Element> insideElements = new HashSet<>();

--- a/structurizr-core/src/com/structurizr/view/ComponentView.java
+++ b/structurizr-core/src/com/structurizr/view/ComponentView.java
@@ -143,19 +143,22 @@ public class ComponentView extends StaticView {
      * and relationships are added to the view:</p>
      * <ul>
      * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that have direct {@link Relationship}s to
-     * this elements in this view including the Container itself</li>
-     * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that are referenced by the
-     * {@link Container} of this view or one of the {@link Element}s in this view</li>
+     * all {@link Component}s in this view</li>
+     * <li>all other {@link Element}s (Person, SoftwareSystem, Container or Component) that are referenced by one
+     * of the {@link Component}s in this view</li>
      * </ul>
-     * <p>{@link Relationship}s between external {@link Element}s (i.e. elements that are not part of this container) are
-     * removed from the view though.
+     * <p>
+     * Not included are:
+     * <ul>
+     * <li>References to and from the {@link Container} of this view (only references to and from the components are considered)</li>
+     * <li>{@link Relationship}s between external {@link Element}s (i.e. elements that are not part of this container)</li>
+     * </ul>
      * </p>
      * <p>Don't forget to add elements to your view prior to calling this method, e.g. by calling {@link #addAllComponents()}
      * or be selectively choosing certain components.</p>
      */
     public void addDirectDependencies() {
         final Set<Element> insideElements = new HashSet<>();
-        insideElements.add(getContainer());
         getElements().stream()
                 .map(ElementView::getElement)
                 .filter(e -> e instanceof Component)

--- a/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
@@ -467,4 +467,30 @@ public class ComponentViewTests extends AbstractWorkspaceTestBase {
         assertThat(view.getElements()).doesNotContain(new ElementView(componentA2_1));
     }
 
+    @Test
+    public void test_addDirectDependencies_AddsElementsWithoutRelationships_WhenThereAreNoRelationshipsWithTheComponents() {
+        SoftwareSystem source = model.addSoftwareSystem("Source", "");
+        SoftwareSystem destination = model.addSoftwareSystem("Destination", "");
+
+        SoftwareSystem a = model.addSoftwareSystem("A", "");
+        Container aa = a.addContainer("AA", "", "");
+        Component aaa1 = aa.addComponent("AAA1", "", "");
+
+        source.uses(aa, "");
+        aa.uses(destination, "");
+
+        view = new ComponentView(aa, "");
+        view.addAllComponents();
+        view.addDirectDependencies();
+
+        // check that the view includes the desired elements
+        Set<Element> elementsInView = view.getElements().stream().map(ElementView::getElement).collect(Collectors.toSet());
+        assertTrue(elementsInView.contains(source));
+        assertTrue(elementsInView.contains(aaa1));
+        assertTrue(elementsInView.contains(destination));
+
+        // but there are no relationships between them
+        assertEquals(0, view.getRelationships().size());
+    }
+
 }

--- a/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
@@ -408,11 +408,21 @@ public class ComponentViewTests extends AbstractWorkspaceTestBase {
         expectedRelationshipsInView.add(componentA1_1.uses(componentA1_3, ""));
 
         final Container containerA2 = softwareSystemA.addContainer("Container A2", "Description", "Tec");
+        final Component componentA2_1 = containerA2.addComponent("Component A2-1", "Description");
+
         expectedRelationshipsInView.add(componentA1_1.uses(containerA2, ""));
         expectedElementsInView.add(containerA2);
 
+        componentA2_1.uses(componentA1_1, ""); // this relationship must not be part of the diagram as componentA2_1 is from another container
+
         final Container containerA3 = softwareSystemA.addContainer("Container A3", "Description", "Tec");
         containerA2.uses(containerA3, ""); // this relationship must not make it into the view as it is outside of our container
+
+        final Container containerA4 = softwareSystemA.addContainer("Container A4", "Description", "Tec");
+        final Component componentA4_1 = containerA4.addComponent("Component A3-1", "Description");
+        componentA4_1.uses(componentA1_1, ""); // this relationship must not be part of the diagram as componentA2_1 is from another container
+        expectedElementsInView.add(containerA4);
+
 
         expectedRelationshipsInView.add(userA.uses(componentA1_1, ""));
         expectedElementsInView.add(userA);

--- a/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
@@ -485,11 +485,8 @@ public class ComponentViewTests extends AbstractWorkspaceTestBase {
 
         // check that the view includes the desired elements
         Set<Element> elementsInView = view.getElements().stream().map(ElementView::getElement).collect(Collectors.toSet());
-        assertTrue(elementsInView.contains(source));
         assertTrue(elementsInView.contains(aaa1));
-        assertTrue(elementsInView.contains(destination));
 
-        // but there are no relationships between them
         assertEquals(0, view.getRelationships().size());
     }
 

--- a/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
@@ -427,4 +427,34 @@ public class ComponentViewTests extends AbstractWorkspaceTestBase {
         assertThat(view.getRelationships()).isEqualTo(expectedRelationshipsInView.stream().map(e -> new RelationshipView(e)).collect(Collectors.toSet()));
     }
 
+    /**
+     * When someone tries to add a component of another container to a container view, then this must not be added
+     */
+    @Test
+    public void test_AddComponentFromOtherContainer() {
+        SoftwareSystem softwareSystemA = model.addSoftwareSystem("System A", "Description");
+
+        final Container containerA1 = softwareSystemA.addContainer("Container A1", "Description", "Tec");
+        final Component componentA1_1 = containerA1.addComponent("Component A1-1", "Description");
+
+
+        final Container containerA2 = softwareSystemA.addContainer("Container A2", "Description", "Tec");
+        final Component componentA2_1 = containerA2.addComponent("Component A2-1", "Description");
+
+        view = new ComponentView(containerA1, "");
+        view.addAllComponents();
+
+        assertThat(view.getElements()).contains(new ElementView(componentA1_1));
+
+        // manually add another container to the view
+        view.add(containerA2);
+        // container should be added to the view
+        assertThat(view.getElements()).contains(new ElementView(containerA2));
+
+        // now manually add a component from another container to the view
+        view.add(componentA2_1);
+        // component must not be added to the view
+        assertThat(view.getElements()).doesNotContain(new ElementView(componentA2_1));
+    }
+
 }

--- a/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/ComponentViewTests.java
@@ -420,7 +420,8 @@ public class ComponentViewTests extends AbstractWorkspaceTestBase {
         softwareSystemA.uses(softwareSystemB, "");// this relationship must not make it into the view as it is outside of our container
 
         view = new ComponentView(containerA1, "");
-        view.addAllComponentsAndDirectDependencies();
+        view.addAllComponents();
+        view.addDirectDependencies();
 
         assertThat(view.getElements()).isEqualTo(expectedElementsInView.stream().map(e -> new ElementView(e)).collect(Collectors.toSet()));
         assertThat(view.getRelationships()).isEqualTo(expectedRelationshipsInView.stream().map(e -> new RelationshipView(e)).collect(Collectors.toSet()));


### PR DESCRIPTION
The idea behind this new method is to provide a convenience method to show all components of a container in the ComponentView as well as all ingoing and outgoing elements (persons, software systems, containers, components from other containers).

That way I get a view of my container who it is influencing and whom it is influenced by.

Relationships between between elements outside my container are removed, that means, if I have 3 containers:

A -> B
A -> C
B -> C

when I have a look at the ContainerView of A, then I want to see B and C with the relationships to A, but I do not want to see the relationship between B and C there

see https://structurizr.com/workspace/111#2 and https://structurizr.com/workspace/111#3 as examples of that code