### PR TITLE
Fixed reference issue between siblings implementing the same interface.

### DIFF
--- a/structurizr-core/src/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategy.java
@@ -65,7 +65,7 @@ public abstract class AbstractReflectionsComponentFinderStrategy extends Compone
 
                 // if there was no component of the interface type, perhaps there is one of the implementation type
                 CtClass referencedTypeAsClass = pool.get(referencedTypeName);
-                if (destinationComponent == null && referencedTypeAsClass.isInterface()) {
+                if (destinationComponent == null && referencedTypeAsClass.isInterface() && !cc.subtypeOf(referencedTypeAsClass)) {
                     Class implementationClass = getFirstImplementationOfInterface(Class.forName(referencedTypeName));
                     if (implementationClass != null) {
                         destinationComponent = componentFinder.getContainer().getComponentOfType(implementationClass.getCanonicalName());

--- a/structurizr-core/test/unit/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategyTests.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class AbstractReflectionsComponentFinderStrategyTests {
 
@@ -65,20 +66,26 @@ public class AbstractReflectionsComponentFinderStrategyTests {
         );
         componentFinder.findComponents();
 
-        assertEquals(2, webApplication.getComponents().size());
+        assertEquals(3, webApplication.getComponents().size());
 
         Component someComponent = webApplication.getComponentWithName("SomeComponent");
         assertNotNull(someComponent);
         assertEquals("SomeComponent", someComponent.getName());
         assertEquals("com.structurizr.componentfinder.subtypes.SomeComponent", someComponent.getType());
 
+        Component otherComponent = webApplication.getComponentWithName("OtherComponent");
+        assertNotNull(otherComponent);
+        assertEquals("OtherComponent", otherComponent.getName());
+        assertEquals("com.structurizr.componentfinder.subtypes.OtherComponent", otherComponent.getType());
+
         Component loggingComponent = webApplication.getComponentWithName("LoggingComponent");
         assertNotNull(loggingComponent);
         assertEquals("LoggingComponent", loggingComponent.getName());
         assertEquals("com.structurizr.componentfinder.subtypes.LoggingComponent", loggingComponent.getType());
 
-        assertEquals(1, someComponent.getRelationships().size());
         assertNotNull(someComponent.getRelationships().stream().filter(r -> r.getDestination() == loggingComponent).findFirst().get());
+        assertNull(someComponent.getRelationships().stream().filter(r -> r.getDestination() == otherComponent).findFirst().orElse(null));
+        assertNull(otherComponent.getRelationships().stream().filter(r -> r.getDestination() == someComponent).findFirst().orElse(null));
     }
 
     @Test

--- a/structurizr-core/test/unit/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/componentfinder/AbstractReflectionsComponentFinderStrategyTests.java
@@ -83,6 +83,7 @@ public class AbstractReflectionsComponentFinderStrategyTests {
         assertEquals("LoggingComponent", loggingComponent.getName());
         assertEquals("com.structurizr.componentfinder.subtypes.LoggingComponent", loggingComponent.getType());
 
+        assertEquals(1, someComponent.getRelationships().size());
         assertNotNull(someComponent.getRelationships().stream().filter(r -> r.getDestination() == loggingComponent).findFirst().get());
         assertNull(someComponent.getRelationships().stream().filter(r -> r.getDestination() == otherComponent).findFirst().orElse(null));
         assertNull(otherComponent.getRelationships().stream().filter(r -> r.getDestination() == someComponent).findFirst().orElse(null));

--- a/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/FeatureInterface.java
+++ b/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/FeatureInterface.java
@@ -1,0 +1,4 @@
+package com.structurizr.componentfinder.subtypes;
+
+public interface FeatureInterface {
+}

--- a/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/OtherComponent.java
+++ b/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/OtherComponent.java
@@ -1,0 +1,4 @@
+package com.structurizr.componentfinder.subtypes;
+
+public class OtherComponent implements FeatureInterface {
+}

--- a/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/SomeComponent.java
+++ b/structurizr-core/test/unit/com/structurizr/componentfinder/subtypes/SomeComponent.java
@@ -1,4 +1,4 @@
 package com.structurizr.componentfinder.subtypes;
 
-public class SomeComponent extends ComponentBase {
+public class SomeComponent extends ComponentBase implements FeatureInterface {
 }


### PR DESCRIPTION
Hi Simon, hope you are doing well!

Just played a bit with your structurizr lib and find a small issue. When two isolated classes implement the same interface, the `AbstractReflectionsComponentFinderStrategy.addEfferentDependencies()` method will somehow wrongly link them to each other due to the `getFirstImplementationOfInterface` fallback.

The problem is illustrated by the test classes added with this PR under `com.structurizr.componentfinder.subtypes` package. There are two components `SomeComponent` and `OtherComponent` both implements `FeatureInterface`. They don't reference to each other but before the fix, you will still get either `SomeComponent` => `OtherComponent` or the other way round depending which one is considered as the _first implementation of the interface_.