### PR TITLE
log warnings for relationships with missing description or technology

### DIFF
--- a/structurizr-core/src/com/structurizr/api/StructurizrClient.java
+++ b/structurizr-core/src/com/structurizr/api/StructurizrClient.java
@@ -336,6 +336,16 @@ public final class StructurizrClient {
                 .filter(c -> c.getTechnology() == null || c.getTechnology().trim().length() == 0)
                 .forEach(c -> log.warn("Container " + c.getCanonicalName() + ": Missing technology")));
 
+        // find relationships with a missing description
+        workspace.getModel().getRelationships().stream()
+                .filter(e -> e.getDescription() == null || e.getDescription().trim().length() == 0)
+                .forEach(e -> log.warn(e.getClass().getSimpleName() + " " + e.toString() + ": Missing description"));
+
+        // find relationships with a missing technology
+        workspace.getModel().getRelationships().stream()
+                .filter(e -> e.getTechnology() == null || e.getTechnology().trim().length() == 0)
+                .forEach(e -> log.warn(e.getClass().getSimpleName() + " " + e.toString() + ": Missing technology"));
+
         // diagram keys have not been specified
         workspace.getViews().getEnterpriseContextViews().stream()
                 .filter(v -> v.getKey() == null)


### PR DESCRIPTION
btw: I would extract the method findAndLogWarnings from StructurizrClient to a public utility method so that users can call that method without pushing the model to structurizr (probably also return the number of warnings in the method signature, that way one could ensure to only push models without warnings)