### PR TITLE
Make getContainer and getPackagesToScan public.

### DIFF
--- a/structurizr-core/src/com/structurizr/componentfinder/ComponentFinder.java
+++ b/structurizr-core/src/com/structurizr/componentfinder/ComponentFinder.java
@@ -43,11 +43,11 @@ public class ComponentFinder {
         return componentsFound;
     }
 
-    Container getContainer() {
+    public Container getContainer() {
         return this.container;
     }
 
-    String getPackageToScan() {
+    public String getPackageToScan() {
         return packageToScan;
     }
 


### PR DESCRIPTION
3rd party component finder strategies living in different packages can now use
those functions.