### PR TITLE
PlantUMLWriter limits diagram dimensions to match PaperSize or sizeLimit

### DIFF
--- a/structurizr-core/src/com/structurizr/io/plantuml/PlantUMLWriter.java
+++ b/structurizr-core/src/com/structurizr/io/plantuml/PlantUMLWriter.java
@@ -26,6 +26,8 @@ import static java.util.Collections.emptyList;
  */
 public final class PlantUMLWriter implements WorkspaceWriter {
 
+    /** Maximum diagram width or height. Defaults to 2000 to match public plantuml.com installation */
+    private int sizeLimit = 2000;
     private boolean includeNotesForActors = true;
     private final Map<String, String> skinParams = new LinkedHashMap<>();
 
@@ -46,6 +48,10 @@ public final class PlantUMLWriter implements WorkspaceWriter {
 
     public void setIncludeNotesForActors(boolean includeNotesForActors) {
         this.includeNotesForActors = includeNotesForActors;
+    }
+
+    public void setSizeLimit(int sizeLimit) {
+        this.sizeLimit = sizeLimit;
     }
 
     @Override
@@ -500,6 +506,27 @@ public final class PlantUMLWriter implements WorkspaceWriter {
 
     private void writeHeader(View view, Writer writer) throws IOException {
         writer.write("@startuml");
+        writer.write(System.lineSeparator());
+
+        PaperSize size = view.getPaperSize();
+        int width;
+        int height;
+        if(size==null) {
+            width = height = sizeLimit;
+        }
+        else {
+            width = size.getWidth();
+            height = size.getHeight();
+            if(width>sizeLimit || height>sizeLimit) {
+                int max = Math.max(width, height);
+                width = (width * sizeLimit) / max;
+                height = (height * sizeLimit) / max;
+            }
+        }
+        writer.write("scale max ");
+        writer.write(Integer.toString(width));
+        writer.write("x");
+        writer.write(Integer.toString(height));
         writer.write(System.lineSeparator());
 
         writer.write("title " + view.getName());

--- a/structurizr-core/test/unit/com/structurizr/io/plantuml/PlantUMLWriterTests.java
+++ b/structurizr-core/test/unit/com/structurizr/io/plantuml/PlantUMLWriterTests.java
@@ -21,6 +21,11 @@ public class PlantUMLWriterTests {
     @Before
     public void setUp() {
         plantUMLWriter = new PlantUMLWriter();
+
+        // Public plantuml.com/plantuml server limits dimensions to 2000, but local servers can be configured
+        // differently. Setting limit here to 1999 to be provably different to plantuml.com AND still usable at the
+        // public server AND bigger than A6 so that we can ensure smaller paper sizes are respected correctly.
+        plantUMLWriter.setSizeLimit(1999);
         workspace = new Workspace("Name", "Description");
         stringWriter = new StringWriter();
     }
@@ -169,9 +174,11 @@ public class PlantUMLWriterTests {
         systemContextView.addAllElements();
 
         ContainerView containerView = workspace.getViews().createContainerView(softwareSystem, "containers", "");
+        containerView.setPaperSize(PaperSize.A2_Landscape);
         containerView.addAllElements();
 
         ComponentView componentView = workspace.getViews().createComponentView(webApplication, "components", "");
+        componentView.setPaperSize(PaperSize.A6_Portrait);
         componentView.addAllElements();
 
         DynamicView dynamicView = workspace.getViews().createDynamicView(webApplication, "dynamic", "");
@@ -219,6 +226,7 @@ public class PlantUMLWriterTests {
         plantUMLWriter.write(workspace, stringWriter);
 
         assertEquals("@startuml" + System.lineSeparator() +
+                "scale max 1999x1999" + System.lineSeparator() +
                 "title Enterprise Context" + System.lineSeparator() +
                 "" + System.lineSeparator() +
                 "skinparam {" + System.lineSeparator() +
@@ -251,6 +259,7 @@ public class PlantUMLWriterTests {
         plantUMLWriter.write(workspace, stringWriter);
 
         assertEquals("@startuml" + System.lineSeparator() +
+                "scale max 1999x1999" + System.lineSeparator() +
                 "title My software system - System Context" + System.lineSeparator() +
                 "" + System.lineSeparator() +
                 "skinparam {" + System.lineSeparator() +
@@ -269,6 +278,7 @@ public class PlantUMLWriterTests {
     }
 
     private static final String ENTERPRISE_CONTEXT_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1999x1999" + System.lineSeparator() +
             "title Enterprise Context for Some Enterprise" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +
@@ -302,6 +312,7 @@ public class PlantUMLWriterTests {
             "@enduml" + System.lineSeparator();
 
     private static final String SYSTEM_CONTEXT_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1999x1999" + System.lineSeparator() +
             "title Software System - System Context" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +
@@ -333,6 +344,7 @@ public class PlantUMLWriterTests {
             "@enduml" + System.lineSeparator();
 
     private static final String CONTAINER_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1999x1413" + System.lineSeparator() +
             "title Software System - Containers" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +
@@ -376,6 +388,7 @@ public class PlantUMLWriterTests {
             "@enduml" + System.lineSeparator();
 
     private static final String COMPONENT_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1240x1748" + System.lineSeparator() +
             "title Software System - Web Application - Components" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +
@@ -423,6 +436,7 @@ public class PlantUMLWriterTests {
             "@enduml" + System.lineSeparator();
 
     private static final String DYNAMIC_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1999x1999" + System.lineSeparator() +
             "title Web Application - Dynamic" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +
@@ -458,6 +472,7 @@ public class PlantUMLWriterTests {
             "@enduml" + System.lineSeparator();
 
     private static final String DEPLOYMENT_VIEW = "@startuml" + System.lineSeparator() +
+            "scale max 1999x1999" + System.lineSeparator() +
             "title Software System - Deployment" + System.lineSeparator() +
             "" + System.lineSeparator() +
             "skinparam {" + System.lineSeparator() +

--- a/structurizr-examples/src/com/structurizr/example/PlantUML.java
+++ b/structurizr-examples/src/com/structurizr/example/PlantUML.java
@@ -34,17 +34,17 @@ public class PlantUML {
         contextView.addAllPeople();
         contextView.setPaperSize(PaperSize.Slide_16_9);
 
-//        Styles styles = views.getConfiguration().getStyles();
-//        styles.addElementStyle(Tags.SOFTWARE_SYSTEM).background("#1168bd").color("#ffffff");
-//        styles.addElementStyle(Tags.PERSON).background("#08427b").color("#ffffff").shape(Shape.Person);
+        Styles styles = views.getConfiguration().getStyles();
+        styles.addElementStyle(Tags.SOFTWARE_SYSTEM).background("#1168bd").color("#ffffff");
+        styles.addElementStyle(Tags.PERSON).background("#08427b").color("#ffffff").shape(Shape.Person);
 
         StringWriter stringWriter = new StringWriter();
         PlantUMLWriter plantUMLWriter = new PlantUMLWriter();
 
         // if you're using dark background colours, you might need to explicitly set the foreground colour using skin params
         // e.g. rectangleFontColor, rectangleFontColor<<Software System>>, etc
-//        plantUMLWriter.addSkinParam("rectangleFontColor", "#ffffff");
-//        plantUMLWriter.addSkinParam("rectangleStereotypeFontColor", "#ffffff");
+        plantUMLWriter.addSkinParam("rectangleFontColor", "#ffffff");
+        plantUMLWriter.addSkinParam("rectangleStereotypeFontColor", "#ffffff");
 
         plantUMLWriter.write(workspace, stringWriter);
         System.out.println(stringWriter.toString());

--- a/structurizr-examples/src/com/structurizr/example/PlantUML.java
+++ b/structurizr-examples/src/com/structurizr/example/PlantUML.java
@@ -6,6 +6,7 @@ import com.structurizr.model.Model;
 import com.structurizr.model.Person;
 import com.structurizr.model.SoftwareSystem;
 import com.structurizr.model.Tags;
+import com.structurizr.view.PaperSize;
 import com.structurizr.view.Shape;
 import com.structurizr.view.Styles;
 import com.structurizr.view.SystemContextView;
@@ -31,18 +32,19 @@ public class PlantUML {
         SystemContextView contextView = views.createSystemContextView(softwareSystem, "SystemContext", "An example of a System Context diagram.");
         contextView.addAllSoftwareSystems();
         contextView.addAllPeople();
+        contextView.setPaperSize(PaperSize.Slide_16_9);
 
-        Styles styles = views.getConfiguration().getStyles();
-        styles.addElementStyle(Tags.SOFTWARE_SYSTEM).background("#1168bd").color("#ffffff");
-        styles.addElementStyle(Tags.PERSON).background("#08427b").color("#ffffff").shape(Shape.Person);
+//        Styles styles = views.getConfiguration().getStyles();
+//        styles.addElementStyle(Tags.SOFTWARE_SYSTEM).background("#1168bd").color("#ffffff");
+//        styles.addElementStyle(Tags.PERSON).background("#08427b").color("#ffffff").shape(Shape.Person);
 
         StringWriter stringWriter = new StringWriter();
         PlantUMLWriter plantUMLWriter = new PlantUMLWriter();
 
         // if you're using dark background colours, you might need to explicitly set the foreground colour using skin params
         // e.g. rectangleFontColor, rectangleFontColor<<Software System>>, etc
-        plantUMLWriter.addSkinParam("rectangleFontColor", "#ffffff");
-        plantUMLWriter.addSkinParam("rectangleStereotypeFontColor", "#ffffff");
+//        plantUMLWriter.addSkinParam("rectangleFontColor", "#ffffff");
+//        plantUMLWriter.addSkinParam("rectangleStereotypeFontColor", "#ffffff");
 
         plantUMLWriter.write(workspace, stringWriter);
         System.out.println(stringWriter.toString());


### PR DESCRIPTION
Some of my PlantUMLWriter generated diagrams are wide enough that they get cropped when rendered via the http://plantuml.com/plantuml. To counter that I've created this patch so diagrams are rescaled to be within the limits that can be drawn on and also within the PaperSize dimensions too.

PlantUML apparently does not support reflowing a long diagram to fit onto a wide image or vice versa so rescaling seems to be the only practical option. Initially was going to only include the "scale max" statement when PaperSize was specified but figured that defaulting to be within the server limits was probably sensible too.

Syntax produced:
```
@startuml
scale max 2000x2000
title Software System - System Context
caption An example of a System Context diagram.
...
@enduml
```
[Example](http://www.plantuml.com/plantuml/uml/RP5DQyCm38Rl_XM2dXFINWQZb7wS1uEnK-b1s4eM6bj1LaZAs7-V4venGcGGyljOBq8-HaNHpZScMcm8F0wmAufY69FHMfFsmQNsAAbuH2KFsLnSE2WDQYosMdE0Km0QqBUfXql0nJDmDLQ2FZSctklGOghXsm34BtJSrw624fj8IK4HxY_SiC3cfHZFA5fbERCuaYMox5iE57GT2rd5K3MqZWChdT7UA-4kk2SjfvZfIj-F-RE57UptYoqT3h1nKy0rkIneKh8ifRS7n9d4YUJczizucupVIIA7XTzd99bDJj2bsxXolsgtXVpwdFgM7zAmhsDxD4SABltyBm00)