### PR TITLE
ComponentFinder optionally uses custom URLClassLoader

### DIFF
--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -47,7 +47,7 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
 
     @Override
     public void beforeFindComponents() {
-        typeRepository = new DefaultTypeRepository(componentFinder.getPackageName(), componentFinder.getExclusions());
+        typeRepository = new DefaultTypeRepository(componentFinder.getPackageName(), componentFinder.getExclusions(), componentFinder.getUrlClassLoader());
         supportingTypesStrategies.forEach(sts -> sts.setTypeRepository(typeRepository));
     }
 
@@ -74,12 +74,12 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
     private void findSupportingTypes(Set<Component> components) {
         for (Component component : components) {
             for (CodeElement codeElement : component.getCode()) {
-                TypeVisibility visibility = TypeUtils.getVisibility(codeElement.getType());
+                TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
                 if (visibility != null) {
                     codeElement.setVisibility(visibility.getName());
                 }
 
-                TypeCategory category = TypeUtils.getCategory(codeElement.getType());
+                TypeCategory category = TypeUtils.getCategory(getTypeRepository(), codeElement.getType());
                 if (category != null) {
                     codeElement.setCategory(category.getName());
                 }
@@ -90,12 +90,12 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
                     if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type) == null) {
                         CodeElement codeElement = component.addSupportingType(type);
 
-                        TypeVisibility visibility = TypeUtils.getVisibility(codeElement.getType());
+                        TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
                         if (visibility != null) {
                             codeElement.setVisibility(visibility.getName());
                         }
 
-                        TypeCategory category = TypeUtils.getCategory(codeElement.getType());
+                        TypeCategory category = TypeUtils.getCategory(getTypeRepository(), codeElement.getType());
                         if (category != null) {
                             codeElement.setCategory(category.getName());
                         }

--- a/structurizr-core/src/com/structurizr/analysis/ComponentFinder.java
+++ b/structurizr-core/src/com/structurizr/analysis/ComponentFinder.java
@@ -3,6 +3,7 @@ package com.structurizr.analysis;
 import com.structurizr.model.Component;
 import com.structurizr.model.Container;
 
+import java.net.URLClassLoader;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -12,6 +13,7 @@ import java.util.regex.Pattern;
  */
 public class ComponentFinder {
 
+    private URLClassLoader urlClassLoader;
     private Container container;
     private String packageName;
 
@@ -126,4 +128,19 @@ public class ComponentFinder {
         this.exclusions.clear();
     }
 
+    /**
+     * Sets a classloader to load classes from instead of the system classloader
+     * @param urlClassLoader the classloader to use
+     */
+    public void setUrlClassLoader(URLClassLoader urlClassLoader) {
+        this.urlClassLoader = urlClassLoader;
+    }
+
+    /**
+     * Gets the classloader used to load classes
+     * @return the classloader to use, or null if system classloader
+     */
+    public URLClassLoader getUrlClassLoader() {
+        return urlClassLoader;
+    }
 }

--- a/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
@@ -19,7 +19,7 @@ public class FirstImplementationOfInterfaceSupportingTypesStrategy extends Suppo
         Set<String> set = new HashSet<>();
 
         try {
-            Class componentType = ClassLoader.getSystemClassLoader().loadClass(component.getType());
+            Class componentType = getTypeRepository().loadClass(component.getType());
             if (componentType.isInterface()) {
                 Class type = TypeUtils.findFirstImplementationOfInterface(componentType, getTypeRepository().getAllTypes());
                 if (type != null) {

--- a/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
@@ -88,7 +88,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsesComponentAnnotations(Component component, String typeName) {
         try {
-            Class type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class type = getTypeRepository().loadClass(typeName);
             for (Field field : type.getDeclaredFields()) {
                 UsesComponent annotation = field.getAnnotation(UsesComponent.class);
                 if (annotation != null) {
@@ -119,7 +119,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsesSoftwareSystemsAnnotations(Component component, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = getTypeRepository().loadClass(typeName);
             UsesSoftwareSystem[] annotations = type.getAnnotationsByType(UsesSoftwareSystem.class);
             for (UsesSoftwareSystem annotation : annotations) {
                 String name = annotation.name();
@@ -143,7 +143,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsesContainerAnnotations(Component component, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = getTypeRepository().loadClass(typeName);
             UsesContainer[] annotations = type.getAnnotationsByType(UsesContainer.class);
             for (UsesContainer annotation : annotations) {
                 String name = annotation.name();
@@ -167,7 +167,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsedByPersonAnnotations(Component component, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = getTypeRepository().loadClass(typeName);
             UsedByPerson[] annotations = type.getAnnotationsByType(UsedByPerson.class);
             for (UsedByPerson annotation : annotations) {
                 String name = annotation.name();
@@ -191,7 +191,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsedBySoftwareSystemAnnotations(Component component, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = getTypeRepository().loadClass(typeName);
             UsedBySoftwareSystem[] annotations = type.getAnnotationsByType(UsedBySoftwareSystem.class);
             for (UsedBySoftwareSystem annotation : annotations) {
                 String name = annotation.name();
@@ -215,7 +215,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
      */
     private void findUsedByContainerAnnotations(Component component, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = getTypeRepository().loadClass(typeName);
             UsedByContainer[] annotations = type.getAnnotationsByType(UsedByContainer.class);
             for (UsedByContainer annotation : annotations) {
                 String name = annotation.name();

--- a/structurizr-core/src/com/structurizr/analysis/TypeRepository.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeRepository.java
@@ -33,6 +33,7 @@ interface TypeRepository {
      * Loads the specified type.
      * @param typeName the type to load
      * @return a Class object
+     * @throws ClassNotFoundException if the class cannot be found and created
      */
     Class<?> loadClass(String typeName) throws ClassNotFoundException;
 

--- a/structurizr-core/src/com/structurizr/analysis/TypeRepository.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeRepository.java
@@ -29,4 +29,11 @@ interface TypeRepository {
      */
     Set<Class<?>> findReferencedTypes(String typeName);
 
+    /**
+     * Loads the specified type.
+     * @param typeName the type to load
+     * @return a Class object
+     */
+    Class<?> loadClass(String typeName) throws ClassNotFoundException;
+
 }

--- a/structurizr-core/src/com/structurizr/analysis/TypeUtils.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeUtils.java
@@ -18,12 +18,13 @@ public class TypeUtils {
     /**
      * Finds the visibility of a given type.
      *
-     * @param typeName  the fully qualified type name
-     * @return          a TypeVisibility object representing the visibility (e.g. public, package, etc)
+     * @param typeRepository the repository where types should be loaded from
+     * @param typeName       the fully qualified type name
+     * @return               a TypeVisibility object representing the visibility (e.g. public, package, etc)
      */
-    public static TypeVisibility getVisibility(String typeName) {
+    public static TypeVisibility getVisibility(TypeRepository typeRepository, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = typeRepository.loadClass(typeName);
             int modifiers = type.getModifiers();
             if (Modifier.isPrivate(modifiers)) {
                 return TypeVisibility.PRIVATE;
@@ -43,12 +44,13 @@ public class TypeUtils {
     /**
      * Finds the category of a given type.
      *
-     * @param typeName  the fully qualified type name
-     * @return          a TypeCategory object representing the category (e.g. class, interface, enum, etc)
+     * @param typeRepository the repository where types should be loaded from
+     * @param typeName       the fully qualified type name
+     * @return               a TypeCategory object representing the category (e.g. class, interface, enum, etc)
      */
-    public static TypeCategory getCategory(String typeName) {
+    public static TypeCategory getCategory(TypeRepository typeRepository, String typeName) {
         try {
-            Class<?> type = ClassLoader.getSystemClassLoader().loadClass(typeName);
+            Class<?> type = typeRepository.loadClass(typeName);
             if (type.isInterface()) {
                 return TypeCategory.INTERFACE;
             } else if (type.isEnum()) {

--- a/structurizr-core/test/unit/com/structurizr/analysis/DefaultTypeRepositoryTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/DefaultTypeRepositoryTests.java
@@ -16,14 +16,14 @@ public class DefaultTypeRepositoryTests {
 
     @Test
     public void test_getAllTypes_ReturnsAnEmptySet_WhenNoTypesWereFound() {
-        typeRepository = new DefaultTypeRepository("com.structurizr.analysis.foo", new HashSet<>());
+        typeRepository = new DefaultTypeRepository("com.structurizr.analysis.foo", new HashSet<>(), null);
         Set<Class<?>> types = typeRepository.getAllTypes();
         assertTrue(types.isEmpty());
     }
 
     @Test
     public void test_getAllTypes_ReturnsANonEmptySet_WhenTypesWereFound() {
-        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>());
+        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>(), null);
         Set<String> types = typeRepository.getAllTypes().stream().map(Class::getCanonicalName).collect(Collectors.toSet());
         assertEquals(4, types.size());
 
@@ -37,7 +37,7 @@ public class DefaultTypeRepositoryTests {
     public void test_getAllTypes_ReturnsANonEmptySet_WhenTypesAreFoundAndExclusionsHaveBeenSpecified() {
         Set<Pattern> exclusions = new HashSet<>();
         exclusions.add(Pattern.compile(".*Abstract.*"));
-        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", exclusions);
+        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", exclusions, null);
         Set<String> types = typeRepository.getAllTypes().stream().map(Class::getCanonicalName).collect(Collectors.toSet());
         assertEquals(3, types.size());
 
@@ -48,7 +48,7 @@ public class DefaultTypeRepositoryTests {
 
     @Test
     public void test_findReferencedTypes_ReturnsASetOnlyContainingJavaLangObject_WhenThereAreNoTypesReferenced() throws Exception {
-        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>());
+        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>(), null);
         Set<String> types = typeRepository.findReferencedTypes("test.DefaultTypeRepository.SomeInterface").stream().map(Class::getCanonicalName).collect(Collectors.toSet());
         assertEquals(1, types.size());
 
@@ -57,7 +57,7 @@ public class DefaultTypeRepositoryTests {
 
     @Test
     public void test_findReferencedTypes_ReturnsANonEmptySet_WhenThereAreTypesReferenced() throws Exception {
-        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>());
+        typeRepository = new DefaultTypeRepository("test.DefaultTypeRepository", new HashSet<>(), null);
         Set<String> types = typeRepository.findReferencedTypes("test.DefaultTypeRepository.SomeClass").stream().map(Class::getCanonicalName).collect(Collectors.toSet());
         assertEquals(3, types.size());
 

--- a/structurizr-core/test/unit/com/structurizr/analysis/TypeUtilsTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/TypeUtilsTests.java
@@ -9,53 +9,60 @@ import test.TypeUtils.SomeInterface;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TypeUtilsTests {
 
+    private static final TypeRepository types = new DefaultTypeRepository("", emptySet(), null);
+
     @Test
     public void test_getCategory_ReturnsNull_WhenTheSpecifiedTypeCouldNotBeFound() throws Exception {
-        assertNull(TypeUtils.getCategory("com.company.app.Class"));
+        assertNull(TypeUtils.getCategory(types, "com.company.app.Class"));
     }
 
     @Test
     public void test_getCategory_ReturnsInterface_WhenTheSpecifiedTypeIsAnInterface() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory("test.TypeUtils.SomeInterface");
+        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeInterface");
         assertSame(TypeCategory.INTERFACE, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsAbstractClass_WhenTheSpecifiedTypeIsAnAbstractClass() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory("test.TypeUtils.SomeAbstractClass");
+        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeAbstractClass");
         assertSame(TypeCategory.ABSTRACT_CLASS, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsAbstractClass_WhenTheSpecifiedTypeIsAClass() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory("test.TypeUtils.SomeClass");
+        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeClass");
         assertSame(TypeCategory.CLASS, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsEnum_WhenTheSpecifiedTypeIsAnEnum() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory("test.TypeUtils.SomeEnum");
+        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeEnum");
         assertSame(TypeCategory.ENUM, typeCategory);
     }
 
     @Test
     public void test_getVisibility_ReturnsNull_WhenTheSpecifiedTypeCouldNotBeFound() throws Exception {
-        assertNull(TypeUtils.getVisibility("com.company.app.Class"));
+        assertNull(TypeUtils.getVisibility(types, "com.company.app.Class"));
     }
 
     @Test
     public void test_getVisibility_ReturnsPublic_WhenTheSpecifiedTypeIsPublic() throws Exception {
-        TypeVisibility typeCategory= TypeUtils.getVisibility("test.TypeUtils.SomeInterface");
+        TypeVisibility typeCategory= TypeUtils.getVisibility(types, "test.TypeUtils.SomeInterface");
         assertSame(TypeVisibility.PUBLIC, typeCategory);
     }
 
     @Test
     public void test_getVisibility_ReturnsPackage_WhenTheSpecifiedTypeIsPackageScoped() throws Exception {
-        TypeVisibility typeCategory= TypeUtils.getVisibility("test.TypeUtils.SomeClass");
+        TypeVisibility typeCategory= TypeUtils.getVisibility(types, "test.TypeUtils.SomeClass");
         assertSame(TypeVisibility.PACKAGE, typeCategory);
     }
 


### PR DESCRIPTION
* ComponentFinder now has optional urlClassLoader property
* DefaultTypeRepository now handles nearly all ClassLoader usage
* DefaultTypeRepository defaults to system class loader but can be overridden by ComponentFinder.urlClassLoader.

Note that Component.getPackage() still uses the system class loader for now. Seems this ought to be a proper property and set by the ComponentFinder infrastructure to me.

Also, is there any reason not to reuse a TypeRepository instance between strategies? Seems that we waste time rescanning if multiple AbstractComponentFinderStrategy instances are in use.