### PR TITLE
Move type and package properties from Component to CodeElement

### DIFF
--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -88,7 +88,7 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
             for (SupportingTypesStrategy strategy : supportingTypesStrategies) {
                 for (Class<?> type : strategy.findSupportingTypes(component)) {
                     if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type.getCanonicalName()) == null) {
-                        CodeElement codeElement = component.addSupportingType(type.getCanonicalName());
+                        CodeElement codeElement = component.addSupportingType(type);
 
                         TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
                         if (visibility != null) {
@@ -168,9 +168,8 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
         Set<Class<?>> componentTypes = findTypesAnnotatedWith(type);
         for (Class<?> componentType : componentTypes) {
             if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                components.add(getComponentFinder().getContainer().addComponent(
-                        componentType.getSimpleName(),
-                        componentType.getCanonicalName(),
+                components.add(getComponentFinder().getContainer().addComponentAndCode(
+                        componentType,
                         "",
                         technology));
             }

--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -73,32 +73,10 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
 
     private void findSupportingTypes(Set<Component> components) {
         for (Component component : components) {
-            for (CodeElement codeElement : component.getCode()) {
-                TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
-                if (visibility != null) {
-                    codeElement.setVisibility(visibility.getName());
-                }
-
-                TypeCategory category = TypeUtils.getCategory(getTypeRepository(), codeElement.getType());
-                if (category != null) {
-                    codeElement.setCategory(category.getName());
-                }
-            }
-
             for (SupportingTypesStrategy strategy : supportingTypesStrategies) {
                 for (Class<?> type : strategy.findSupportingTypes(component)) {
                     if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type.getCanonicalName()) == null) {
-                        CodeElement codeElement = component.addSupportingType(type);
-
-                        TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
-                        if (visibility != null) {
-                            codeElement.setVisibility(visibility.getName());
-                        }
-
-                        TypeCategory category = TypeUtils.getCategory(getTypeRepository(), codeElement.getType());
-                        if (category != null) {
-                            codeElement.setCategory(category.getName());
-                        }
+                        component.addSupportingType(type);
                     }
                 }
             }

--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -76,7 +76,7 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
             for (SupportingTypesStrategy strategy : supportingTypesStrategies) {
                 for (Class<?> type : strategy.findSupportingTypes(component)) {
                     if (!isNestedClass(type) && componentFinder.getContainer().getComponentWithCode(type) == null) {
-                        component.addSupportingType(type);
+                        component.addSupportingCode(type);
                     }
                 }
             }

--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -86,9 +86,9 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
             }
 
             for (SupportingTypesStrategy strategy : supportingTypesStrategies) {
-                for (String type : strategy.findSupportingTypes(component)) {
-                    if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type) == null) {
-                        CodeElement codeElement = component.addSupportingType(type);
+                for (Class<?> type : strategy.findSupportingTypes(component)) {
+                    if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type.getCanonicalName()) == null) {
+                        CodeElement codeElement = component.addSupportingType(type.getCanonicalName());
 
                         TypeVisibility visibility = TypeUtils.getVisibility(getTypeRepository(), codeElement.getType());
                         if (visibility != null) {
@@ -105,8 +105,8 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
         }
     }
 
-    private boolean isNestedClass(String type) {
-        return type != null && type.indexOf('$') > -1;
+    private boolean isNestedClass(Class<?> type) {
+        return type != null && type.getName().indexOf('$') > -1;
     }
 
     private void findDependencies() {

--- a/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -75,7 +75,7 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
         for (Component component : components) {
             for (SupportingTypesStrategy strategy : supportingTypesStrategies) {
                 for (Class<?> type : strategy.findSupportingTypes(component)) {
-                    if (!isNestedClass(type) && componentFinder.getContainer().getComponentOfType(type.getCanonicalName()) == null) {
+                    if (!isNestedClass(type) && componentFinder.getContainer().getComponentWithCode(type) == null) {
                         component.addSupportingType(type);
                     }
                 }
@@ -89,13 +89,9 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
 
     private void findDependencies() {
         for (Component component : componentFinder.getContainer().getComponents()) {
-            if (component.getType() != null) {
-                addEfferentDependencies(component, component.getType(), new HashSet<>());
-
-                // and repeat for the supporting types
-                for (CodeElement codeElement : component.getCode()) {
-                    addEfferentDependencies(component, codeElement.getType(), new HashSet<>());
-                }
+            // and repeat for the supporting types
+            for (CodeElement codeElement : component.getCode()) {
+                addEfferentDependencies(component, codeElement.getType(), new HashSet<>());
             }
         }
     }
@@ -106,7 +102,7 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
         for (Class<?> referencedType : getTypeRepository().findReferencedTypes(type)) {
             try {
                 String referencedTypeName = referencedType.getCanonicalName();
-                Component destinationComponent = componentFinder.getContainer().getComponentOfType(referencedTypeName);
+                Component destinationComponent = componentFinder.getContainer().getComponentWithCode(referencedType);
                 if (destinationComponent != null) {
                     if (component != destinationComponent) {
                         component.uses(destinationComponent, "");

--- a/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
@@ -15,15 +15,15 @@ public class FirstImplementationOfInterfaceSupportingTypesStrategy extends Suppo
     private static final Log log = LogFactory.getLog(FirstImplementationOfInterfaceSupportingTypesStrategy.class);
 
     @Override
-    public Set<String> findSupportingTypes(Component component) {
-        Set<String> set = new HashSet<>();
+    public Set<Class<?>> findSupportingTypes(Component component) {
+        Set<Class<?>> set = new HashSet<>();
 
         try {
             Class componentType = getTypeRepository().loadClass(component.getType());
             if (componentType.isInterface()) {
                 Class type = TypeUtils.findFirstImplementationOfInterface(componentType, getTypeRepository().getAllTypes());
                 if (type != null) {
-                    set.add(type.getCanonicalName());
+                    set.add(type);
                 }
             }
         } catch (ClassNotFoundException e) {

--- a/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/FirstImplementationOfInterfaceSupportingTypesStrategy.java
@@ -1,11 +1,14 @@
 package com.structurizr.analysis;
 
+import com.structurizr.model.CodeElement;
 import com.structurizr.model.Component;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import static java.util.Collections.emptySet;
 
 /**
  * If the component type is an interface, this strategy finds the first implementation of that interface.
@@ -16,18 +19,24 @@ public class FirstImplementationOfInterfaceSupportingTypesStrategy extends Suppo
 
     @Override
     public Set<Class<?>> findSupportingTypes(Component component) {
+        CodeElement code = component.getPrimaryCode();
+
+        if (code == null) {
+            return emptySet();
+        }
+
         Set<Class<?>> set = new HashSet<>();
 
         try {
-            Class componentType = getTypeRepository().loadClass(component.getType());
+            Class<?> componentType = getTypeRepository().loadClass(code.getType());
             if (componentType.isInterface()) {
-                Class type = TypeUtils.findFirstImplementationOfInterface(componentType, getTypeRepository().getAllTypes());
+                Class<?> type = TypeUtils.findFirstImplementationOfInterface(componentType, getTypeRepository().getAllTypes());
                 if (type != null) {
                     set.add(type);
                 }
             }
         } catch (ClassNotFoundException e) {
-            log.warn("Could not load type " + component.getType());
+            log.warn("Could not load type " + code.getType());
         }
 
         return set;

--- a/structurizr-core/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java
@@ -1,9 +1,12 @@
 package com.structurizr.analysis;
 
+import com.structurizr.model.CodeElement;
 import com.structurizr.model.Component;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
 
 /**
  * This strategy finds all referenced types in the same package as the component type,
@@ -23,12 +26,17 @@ public class ReferencedTypesInSamePackageSupportingTypesStrategy extends Support
 
     @Override
     public Set<Class<?>> findSupportingTypes(Component component) {
+        final CodeElement code = component.getPrimaryCode();
+        if (code == null) {
+            return emptySet();
+        }
+
         ReferencedTypesSupportingTypesStrategy referencedTypesSupportingTypesStrategy = new ReferencedTypesSupportingTypesStrategy(includeIndirectlyReferencedTypes);
         referencedTypesSupportingTypesStrategy.setTypeRepository(getTypeRepository());
         Set<Class<?>> supportingTypes = referencedTypesSupportingTypesStrategy.findSupportingTypes(component);
 
         return supportingTypes.stream()
-                    .filter(type -> type.getPackage().getName().equals(component.getPackage()))
+                    .filter(type -> type.getPackage().getName().equals(code.getNamespace()))
                     .collect(Collectors.toSet());
     }
 

--- a/structurizr-core/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java
@@ -22,13 +22,13 @@ public class ReferencedTypesInSamePackageSupportingTypesStrategy extends Support
     }
 
     @Override
-    public Set<String> findSupportingTypes(Component component) {
+    public Set<Class<?>> findSupportingTypes(Component component) {
         ReferencedTypesSupportingTypesStrategy referencedTypesSupportingTypesStrategy = new ReferencedTypesSupportingTypesStrategy(includeIndirectlyReferencedTypes);
         referencedTypesSupportingTypesStrategy.setTypeRepository(getTypeRepository());
-        Set<String> supportingTypes = referencedTypesSupportingTypesStrategy.findSupportingTypes(component);
+        Set<Class<?>> supportingTypes = referencedTypesSupportingTypesStrategy.findSupportingTypes(component);
 
         return supportingTypes.stream()
-                    .filter(s -> s.startsWith(component.getPackage()))
+                    .filter(type -> type.getPackage().getName().equals(component.getPackage()))
                     .collect(Collectors.toSet());
     }
 

--- a/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java
@@ -28,7 +28,7 @@ public class ReferencedTypesSupportingTypesStrategy extends SupportingTypesStrat
     }
 
     @Override
-    public Set<String> findSupportingTypes(Component component) {
+    public Set<Class<?>> findSupportingTypes(Component component) {
         Set<Class<?>> referencedTypes = new HashSet<>();
         referencedTypes.addAll(getReferencedTypesInPackage(component.getType()));
 
@@ -55,7 +55,7 @@ public class ReferencedTypesSupportingTypesStrategy extends SupportingTypesStrat
             }
         }
 
-        return referencedTypes.stream().map(Class::getName).collect(Collectors.toSet());
+        return referencedTypes;
     }
 
 }

--- a/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java
@@ -30,7 +30,6 @@ public class ReferencedTypesSupportingTypesStrategy extends SupportingTypesStrat
     @Override
     public Set<Class<?>> findSupportingTypes(Component component) {
         Set<Class<?>> referencedTypes = new HashSet<>();
-        referencedTypes.addAll(getReferencedTypesInPackage(component.getType()));
 
         for (CodeElement codeElement : component.getCode()) {
             referencedTypes.addAll(getReferencedTypesInPackage(codeElement.getType()));

--- a/structurizr-core/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java
@@ -81,7 +81,7 @@ public class SourceCodeComponentFinderStrategy implements ComponentFinderStrateg
                     // additionally set the description on the component, if it's not already been set
                     if (codeElement.getRole() == CodeElementRole.Primary) {
                         if (component.getDescription() == null || component.getDescription().trim().length() == 0) {
-                            component.setDescription(typeToDescription.get(component.getType()));
+                            component.setDescription(typeToDescription.get(codeElement.getType()));
                         }
                     }
                 }

--- a/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
@@ -54,29 +54,27 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
         super.afterFindComponents();
 
         for (Component component : getComponentFinder().getContainer().getComponents()) {
-            if (component.getType() != null) {
 
-                // find the efferent dependencies
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsesComponentAnnotations(component, codeElement.getType());
-                }
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsesSoftwareSystemsAnnotations(component, codeElement.getType());
-                }
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsesContainerAnnotations(component, codeElement.getType());
-                }
+            // find the efferent dependencies
+            for (CodeElement codeElement : component.getCode()) {
+                findUsesComponentAnnotations(component, codeElement.getType());
+            }
+            for (CodeElement codeElement : component.getCode()) {
+                findUsesSoftwareSystemsAnnotations(component, codeElement.getType());
+            }
+            for (CodeElement codeElement : component.getCode()) {
+                findUsesContainerAnnotations(component, codeElement.getType());
+            }
 
-                // and also the afferent dependencies
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsedByPersonAnnotations(component, codeElement.getType());
-                }
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsedBySoftwareSystemAnnotations(component, codeElement.getType());
-                }
-                for (CodeElement codeElement : component.getCode()) {
-                    findUsedByContainerAnnotations(component, codeElement.getType());
-                }
+            // and also the afferent dependencies
+            for (CodeElement codeElement : component.getCode()) {
+                findUsedByPersonAnnotations(component, codeElement.getType());
+            }
+            for (CodeElement codeElement : component.getCode()) {
+                findUsedBySoftwareSystemAnnotations(component, codeElement.getType());
+            }
+            for (CodeElement codeElement : component.getCode()) {
+                findUsedByContainerAnnotations(component, codeElement.getType());
             }
         }
     }
@@ -95,7 +93,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
                     String description = field.getAnnotation(UsesComponent.class).description();
                     String technology = annotation.technology();
 
-                    Component destination = componentFinder.getContainer().getComponentOfType(name);
+                    Component destination = componentFinder.getContainer().getComponentWithCode(field.getType());
                     if (destination != null) {
                         for (Relationship relationship : component.getRelationships()) {
                             if (relationship.getDestination() == destination) {

--- a/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
@@ -36,8 +36,7 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
         // find all types that have been annotated @Component
         Set<Class<?>> componentTypes = findTypesAnnotatedWith(com.structurizr.annotation.Component.class);
         for (Class<?> componentType : componentTypes) {
-            Component component = getComponentFinder().getContainer().addComponent(
-                    componentType.getSimpleName(),
+            Component component = getComponentFinder().getContainer().addComponentAndCode(
                     componentType,
                     componentType.getAnnotation(com.structurizr.annotation.Component.class).description(),
                     componentType.getAnnotation(com.structurizr.annotation.Component.class).technology()

--- a/structurizr-core/src/com/structurizr/analysis/SupportingTypesStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/SupportingTypesStrategy.java
@@ -19,6 +19,6 @@ public abstract class SupportingTypesStrategy {
         this.typeRepository = typeRepository;
     }
 
-    public abstract Set<String> findSupportingTypes(Component component);
+    public abstract Set<Class<?>> findSupportingTypes(Component component);
 
 }

--- a/structurizr-core/src/com/structurizr/analysis/TypeCategory.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeCategory.java
@@ -1,6 +1,20 @@
 package com.structurizr.analysis;
 
+import java.lang.reflect.Modifier;
+
 public final class TypeCategory {
+
+    public static TypeCategory valueOf(Class<?> type) {
+        if (type.isInterface()) {
+            return INTERFACE;
+        } else if (type.isEnum()) {
+            return ENUM;
+        } else if (Modifier.isAbstract(type.getModifiers())) {
+            return ABSTRACT_CLASS;
+        } else{
+            return CLASS;
+        }
+    }
 
     public static final TypeCategory CLASS = new TypeCategory("class");
     public static final TypeCategory INTERFACE = new TypeCategory("interface");

--- a/structurizr-core/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java
@@ -24,9 +24,8 @@ public class TypeMatcherComponentFinderStrategy extends AbstractComponentFinderS
         for (Class type : types) {
             for (TypeMatcher typeMatcher : typeMatchers) {
                 if (typeMatcher.matches(type)) {
-                    Component component = getComponentFinder().getContainer().addComponent(
-                            type.getSimpleName(),
-                            type.getCanonicalName(),
+                    Component component = getComponentFinder().getContainer().addComponentAndCode(
+                            type,
                             typeMatcher.getDescription(),
                             typeMatcher.getTechnology());
                     components.add(component);

--- a/structurizr-core/src/com/structurizr/analysis/TypeUtils.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeUtils.java
@@ -16,59 +16,6 @@ public class TypeUtils {
     private static final Log log = LogFactory.getLog(TypeUtils.class);
 
     /**
-     * Finds the visibility of a given type.
-     *
-     * @param typeRepository the repository where types should be loaded from
-     * @param typeName       the fully qualified type name
-     * @return               a TypeVisibility object representing the visibility (e.g. public, package, etc)
-     */
-    public static TypeVisibility getVisibility(TypeRepository typeRepository, String typeName) {
-        try {
-            Class<?> type = typeRepository.loadClass(typeName);
-            int modifiers = type.getModifiers();
-            if (Modifier.isPrivate(modifiers)) {
-                return TypeVisibility.PRIVATE;
-            } else if (Modifier.isPublic(modifiers)) {
-                return TypeVisibility.PUBLIC;
-            } else if (Modifier.isProtected(modifiers)) {
-                return TypeVisibility.PROTECTED;
-            } else {
-                return TypeVisibility.PACKAGE;
-            }
-        } catch (ClassNotFoundException e) {
-            log.warn("Visibility for type " + typeName + " could not be found.");
-            return null;
-        }
-    }
-
-    /**
-     * Finds the category of a given type.
-     *
-     * @param typeRepository the repository where types should be loaded from
-     * @param typeName       the fully qualified type name
-     * @return               a TypeCategory object representing the category (e.g. class, interface, enum, etc)
-     */
-    public static TypeCategory getCategory(TypeRepository typeRepository, String typeName) {
-        try {
-            Class<?> type = typeRepository.loadClass(typeName);
-            if (type.isInterface()) {
-                return TypeCategory.INTERFACE;
-            } else if (type.isEnum()) {
-                return TypeCategory.ENUM;
-            } else {
-                if (Modifier.isAbstract(type.getModifiers())) {
-                    return TypeCategory.ABSTRACT_CLASS;
-                } else{
-                    return TypeCategory.CLASS;
-                }
-            }
-        } catch (ClassNotFoundException e) {
-            log.warn("Category for type " + typeName + " could not be found.");
-            return null;
-        }
-    }
-
-    /**
      * Finds the set of types that are annotated with the specified annotation.
      *
      * @param annotation        the Annotation to find

--- a/structurizr-core/src/com/structurizr/analysis/TypeVisibility.java
+++ b/structurizr-core/src/com/structurizr/analysis/TypeVisibility.java
@@ -1,6 +1,21 @@
 package com.structurizr.analysis;
 
+import java.lang.reflect.Modifier;
+
 public final class TypeVisibility {
+
+    public static TypeVisibility valueOf(Class<?> type) {
+        int modifiers = type.getModifiers();
+        if (Modifier.isPrivate(modifiers)) {
+            return PRIVATE;
+        } else if (Modifier.isPublic(modifiers)) {
+            return PUBLIC;
+        } else if (Modifier.isProtected(modifiers)) {
+            return PROTECTED;
+        } else {
+            return PACKAGE;
+        }
+    }
 
     public static final TypeVisibility PUBLIC = new TypeVisibility("public");
     public static final TypeVisibility PACKAGE = new TypeVisibility("package");

--- a/structurizr-core/src/com/structurizr/model/CodeElement.java
+++ b/structurizr-core/src/com/structurizr/model/CodeElement.java
@@ -8,6 +8,13 @@ import com.structurizr.util.Url;
  */
 public final class CodeElement {
 
+    private static String requireNonBlank(String value, String message) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(message);
+        }
+        return value;
+    }
+
     /** the role of the code element ... Primary or Supporting */
     private CodeElementRole role = CodeElementRole.Supporting;
 
@@ -16,6 +23,9 @@ public final class CodeElement {
 
     /** the fully qualified type of the code element **/
     private String type;
+
+    /** the namespace of the code element ... typically the package name */
+    private String namespace;
 
     /** a short description of the code element */
     private String description;
@@ -38,19 +48,18 @@ public final class CodeElement {
     CodeElement() {
     }
 
-    CodeElement(String fullyQualifiedTypeName) {
-        if (fullyQualifiedTypeName == null || fullyQualifiedTypeName.trim().isEmpty()) {
-            throw new IllegalArgumentException("A fully qualified name must be provided.");
-        }
+    CodeElement(Class<?> type) {
+        this(
+                type.getSimpleName(),
+                type.getCanonicalName(),
+                type.getPackage() != null ? type.getPackage().getName() : null);
 
-        int dot = fullyQualifiedTypeName.lastIndexOf('.');
-        if (dot > -1) {
-            this.name = fullyQualifiedTypeName.substring(dot+1, fullyQualifiedTypeName.length());
-            this.type = fullyQualifiedTypeName;
-        } else {
-            this.name = fullyQualifiedTypeName;
-            this.type = fullyQualifiedTypeName;
-        }
+    }
+
+    CodeElement(String name, String type, String namespace) {
+        this.name = requireNonBlank(name, "A name must be provided.");
+        this.type = requireNonBlank(type, "A type must be provided.");
+        this.namespace = namespace;
     }
 
     /**
@@ -77,6 +86,19 @@ public final class CodeElement {
 
     void setName(String name) {
         this.name = name;
+    }
+
+    /**
+     * Gets the namespace of this code element.
+     *
+     * @return  the namespace, as a String
+     */
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
     }
 
     /**

--- a/structurizr-core/src/com/structurizr/model/CodeElement.java
+++ b/structurizr-core/src/com/structurizr/model/CodeElement.java
@@ -1,5 +1,7 @@
 package com.structurizr.model;
 
+import com.structurizr.analysis.TypeCategory;
+import com.structurizr.analysis.TypeVisibility;
 import com.structurizr.util.Url;
 
 /**
@@ -53,6 +55,8 @@ public final class CodeElement {
                 type.getSimpleName(),
                 type.getCanonicalName(),
                 type.getPackage() != null ? type.getPackage().getName() : null);
+        this.category = TypeCategory.valueOf(type).getName();
+        this.visibility = TypeVisibility.valueOf(type).getName();
 
     }
 

--- a/structurizr-core/src/com/structurizr/model/Component.java
+++ b/structurizr-core/src/com/structurizr/model/Component.java
@@ -76,19 +76,42 @@ public final class Component extends StaticStructureElement {
     /**
      * Sets the type of this component (e.g. a fully qualified Java interface/class name).
      *
-     * @param type  the fully qualified type name
+     * @param type the primary class for this component
      * @return  the CodeElement that was created
      * @throws IllegalArgumentException if the specified type is null
      */
-    public CodeElement setType(String type) {
+    public CodeElement setType(Class<?> type) {
+        return setType(new CodeElement(type));
+    }
+
+    /**
+     * Sets the type of this component (e.g. a fully qualified Java interface/class name).
+     *
+     * @param name  the name
+     * @param type  the fully qualified type name
+     * @param namespace  the namespace
+     * @return  the CodeElement that was created
+     * @throws IllegalArgumentException if the specified type is null
+     */
+    public CodeElement setType(String name, String type, String namespace) {
+        return setType(new CodeElement(name, type, namespace));
+    }
+
+    /**
+     * Sets the type of this component (e.g. a fully qualified Java interface/class name).
+     *
+     * @param code the primary CodeElement for this component
+     * @return the CodeElement that was created
+     * @throws IllegalArgumentException if the specified type is null
+     */
+    public CodeElement setType(CodeElement code) {
         Optional<CodeElement> optional = codeElements.stream().filter(ce -> ce.getRole() == CodeElementRole.Primary).findFirst();
-        optional.ifPresent(codeElement -> codeElements.remove(codeElement));
+        optional.ifPresent(existing -> codeElements.remove(existing));
 
-        CodeElement codeElement = new CodeElement(type);
-        codeElement.setRole(CodeElementRole.Primary);
-        this.codeElements.add(codeElement);
+        code.setRole(CodeElementRole.Primary);
+        this.codeElements.add(code);
 
-        return codeElement;
+        return code;
     }
 
     /**
@@ -107,16 +130,39 @@ public final class Component extends StaticStructureElement {
     /**
      * Adds a supporting type to this Component.
      *
+     * @param type  a class representing the supporting type
+     * @return  a CodeElement representing the supporting type
+     * @throws IllegalArgumentException if the specified type is null
+     */
+    public CodeElement addSupportingType(Class<?> type) {
+        CodeElement codeElement = new CodeElement(type);
+        return addSupportingType(codeElement);
+    }
+
+    /**
+     * Adds a supporting type to this Component.
+     *
      * @param type  the fully qualified type name
      * @return  a CodeElement representing the supporting type
      * @throws IllegalArgumentException if the specified type is null
      */
-    public CodeElement addSupportingType(String type) {
-        CodeElement codeElement = new CodeElement(type);
-        codeElement.setRole(CodeElementRole.Supporting);
-        this.codeElements.add(codeElement);
+    public CodeElement addSupportingType(String name, String type, String namespace) {
+        CodeElement codeElement = new CodeElement(name, type, namespace);
+        return addSupportingType(codeElement);
+    }
 
-        return codeElement;
+    /**
+     * Adds a supporting type to this Component.
+     *
+     * @param code a CodeElement representing the supporting type
+     * @return  a CodeElement representing the supporting type
+     * @throws IllegalArgumentException if the specified type is null
+     */
+    public CodeElement addSupportingType(CodeElement code) {
+        code.setRole(CodeElementRole.Supporting);
+        this.codeElements.add(code);
+
+        return code;
     }
 
     /**

--- a/structurizr-core/src/com/structurizr/model/Component.java
+++ b/structurizr-core/src/com/structurizr/model/Component.java
@@ -61,38 +61,12 @@ public final class Component extends StaticStructureElement {
     /**
      * Sets the type of this component (e.g. a fully qualified Java interface/class name).
      *
-     * @param type the primary class for this component
-     * @return  the CodeElement that was created
-     * @throws IllegalArgumentException if the specified type is null
-     */
-    @JsonIgnore
-    public CodeElement setType(Class<?> type) {
-        return setType(new CodeElement(type));
-    }
-
-    /**
-     * Sets the type of this component (e.g. a fully qualified Java interface/class name).
-     *
-     * @param name  the name
-     * @param type  the fully qualified type name
-     * @param namespace  the namespace
-     * @return  the CodeElement that was created
-     * @throws IllegalArgumentException if the specified type is null
-     */
-    @JsonIgnore
-    public CodeElement setType(String name, String type, String namespace) {
-        return setType(new CodeElement(name, type, namespace));
-    }
-
-    /**
-     * Sets the type of this component (e.g. a fully qualified Java interface/class name).
-     *
      * @param code the primary CodeElement for this component
      * @return the CodeElement that was created
      * @throws IllegalArgumentException if the specified type is null
      */
     @JsonIgnore
-    public CodeElement setType(CodeElement code) {
+    public CodeElement setPrimaryCode(CodeElement code) {
         Optional.ofNullable(getPrimaryCode())
                 .ifPresent(existing -> codeElements.remove(existing));
 

--- a/structurizr-core/src/com/structurizr/model/Component.java
+++ b/structurizr-core/src/com/structurizr/model/Component.java
@@ -104,9 +104,9 @@ public final class Component extends StaticStructureElement {
      * @return  a CodeElement representing the supporting type
      * @throws IllegalArgumentException if the specified type is null
      */
-    public CodeElement addSupportingType(Class<?> type) {
+    public CodeElement addSupportingCode(Class<?> type) {
         CodeElement codeElement = new CodeElement(type);
-        return addSupportingType(codeElement);
+        return addSupportingCode(codeElement);
     }
 
     /**
@@ -116,9 +116,9 @@ public final class Component extends StaticStructureElement {
      * @return  a CodeElement representing the supporting type
      * @throws IllegalArgumentException if the specified type is null
      */
-    public CodeElement addSupportingType(String name, String type, String namespace) {
+    public CodeElement addSupportingCode(String name, String type, String namespace) {
         CodeElement codeElement = new CodeElement(name, type, namespace);
-        return addSupportingType(codeElement);
+        return addSupportingCode(codeElement);
     }
 
     /**
@@ -128,10 +128,9 @@ public final class Component extends StaticStructureElement {
      * @return  a CodeElement representing the supporting type
      * @throws IllegalArgumentException if the specified type is null
      */
-    public CodeElement addSupportingType(CodeElement code) {
+    public CodeElement addSupportingCode(CodeElement code) {
         code.setRole(CodeElementRole.Supporting);
         this.codeElements.add(code);
-
         return code;
     }
 

--- a/structurizr-core/src/com/structurizr/model/Component.java
+++ b/structurizr-core/src/com/structurizr/model/Component.java
@@ -59,27 +59,13 @@ public final class Component extends StaticStructureElement {
     }
 
     /**
-     * Gets the type of this component (e.g. a fully qualified Java interface/class name).
-     *
-     * @return  the type, as a String
-     */
-    @JsonIgnore
-    public String getType() {
-        final CodeElement code = getPrimaryCode();
-        if (code != null) {
-            return code.getType();
-        } else {
-            return null;
-        }
-    }
-
-    /**
      * Sets the type of this component (e.g. a fully qualified Java interface/class name).
      *
      * @param type the primary class for this component
      * @return  the CodeElement that was created
      * @throws IllegalArgumentException if the specified type is null
      */
+    @JsonIgnore
     public CodeElement setType(Class<?> type) {
         return setType(new CodeElement(type));
     }
@@ -93,6 +79,7 @@ public final class Component extends StaticStructureElement {
      * @return  the CodeElement that was created
      * @throws IllegalArgumentException if the specified type is null
      */
+    @JsonIgnore
     public CodeElement setType(String name, String type, String namespace) {
         return setType(new CodeElement(name, type, namespace));
     }
@@ -104,6 +91,7 @@ public final class Component extends StaticStructureElement {
      * @return the CodeElement that was created
      * @throws IllegalArgumentException if the specified type is null
      */
+    @JsonIgnore
     public CodeElement setType(CodeElement code) {
         Optional.ofNullable(getPrimaryCode())
                 .ifPresent(existing -> codeElements.remove(existing));

--- a/structurizr-core/src/com/structurizr/model/Component.java
+++ b/structurizr-core/src/com/structurizr/model/Component.java
@@ -65,9 +65,9 @@ public final class Component extends StaticStructureElement {
      */
     @JsonIgnore
     public String getType() {
-        Optional<CodeElement> optional = codeElements.stream().filter(ce -> ce.getRole() == CodeElementRole.Primary).findFirst();
-        if (optional.isPresent()) {
-            return optional.get().getType();
+        final CodeElement code = getPrimaryCode();
+        if (code != null) {
+            return code.getType();
         } else {
             return null;
         }
@@ -105,13 +105,21 @@ public final class Component extends StaticStructureElement {
      * @throws IllegalArgumentException if the specified type is null
      */
     public CodeElement setType(CodeElement code) {
-        Optional<CodeElement> optional = codeElements.stream().filter(ce -> ce.getRole() == CodeElementRole.Primary).findFirst();
-        optional.ifPresent(existing -> codeElements.remove(existing));
+        Optional.ofNullable(getPrimaryCode())
+                .ifPresent(existing -> codeElements.remove(existing));
 
         code.setRole(CodeElementRole.Primary);
         this.codeElements.add(code);
 
         return code;
+    }
+
+    public CodeElement getPrimaryCode() {
+        return codeElements
+                .stream()
+                .filter(ce -> ce.getRole() == CodeElementRole.Primary)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -181,24 +189,6 @@ public final class Component extends StaticStructureElement {
      */
     public void setSize(long size) {
         this.size = size;
-    }
-
-    /**
-     * Gets the Java package of this component (i.e. the package of the primary code element).
-     *
-     * @return  the package name, as a String
-     */
-    @JsonIgnore
-    public String getPackage() {
-        if (getType() != null) {
-            try {
-                return ClassLoader.getSystemClassLoader().loadClass(getType()).getPackage().getName();
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            }
-        }
-
-        return null;
     }
 
     @Override

--- a/structurizr-core/src/com/structurizr/model/Container.java
+++ b/structurizr-core/src/com/structurizr/model/Container.java
@@ -66,12 +66,12 @@ public final class Container extends StaticStructureElement {
         return c;
     }
 
-    public Component addComponent(String name, Class type, String description, String technology) {
-        return this.addComponent(name, type.getCanonicalName(), description, technology);
+    public Component addComponentAndCode(Class type, String description, String technology) {
+        return getModel().addComponentAndCode(this, type, description, technology);
     }
 
-    public Component addComponent(String name, String type, String description, String technology) {
-        return getModel().addComponentOfType(this, name, type, description, technology);
+    public Component addComponentAndCode(String name, String type, String namespace, String description, String technology) {
+        return getModel().addComponentAndCode(this, name, type, namespace, description, technology);
     }
 
     void add(Component component) {

--- a/structurizr-core/src/com/structurizr/model/Container.java
+++ b/structurizr-core/src/com/structurizr/model/Container.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A container represents something that hosts code or data. A container is
@@ -98,13 +100,29 @@ public final class Container extends StaticStructureElement {
         return component.orElse(null);
     }
 
-    public Component getComponentOfType(String type) {
-        if (type == null) {
-            return null;
-        }
+    public Component getComponentWithCode(Class<?> type) {
+        return getComponentWithCode(new CodeElement(type));
+    }
 
-        Optional<Component> component = components.stream().filter(c -> type.equals(c.getType())).findFirst();
-        return component.orElse(null);
+    public Component getComponentWithCode(String name, String type, String namespace) {
+        return getComponentWithCode(new CodeElement(name, type, namespace));
+    }
+
+    private Component getComponentWithCode(CodeElement filter) {
+        return getComponent(component -> {
+            final CodeElement code = component.getPrimaryCode();
+            return  Objects.equals(filter.getName(), code.getName()) &&
+                    Objects.equals(filter.getType(), code.getType()) &&
+                    Objects.equals(filter.getNamespace(), code.getNamespace());
+        });
+    }
+
+    private Component getComponent(Predicate<Component> filter) {
+        return components
+                .stream()
+                .filter(filter)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/structurizr-core/src/com/structurizr/model/Model.java
+++ b/structurizr-core/src/com/structurizr/model/Model.java
@@ -140,7 +140,7 @@ public final class Model {
     Component addComponentAndCode(Container parent, CodeElement code, String description, String technology) {
         Component component = new Component();
         component.setName(code.getName());
-        component.setType(code);
+        component.setPrimaryCode(code);
         component.setDescription(description);
         component.setTechnology(technology);
 

--- a/structurizr-core/src/com/structurizr/model/Model.java
+++ b/structurizr-core/src/com/structurizr/model/Model.java
@@ -129,10 +129,18 @@ public final class Model {
         }
     }
 
-    Component addComponentOfType(Container parent, String name, String type, String description, String technology) {
+    Component addComponentAndCode(Container parent, Class<?> type, String description, String technology) {
+        return addComponentAndCode(parent, new CodeElement(type), description, technology);
+    }
+
+    Component addComponentAndCode(Container parent, String name, String type, String namespace, String description, String technology) {
+        return addComponentAndCode(parent, new CodeElement(name, type, namespace), description, technology);
+    }
+
+    Component addComponentAndCode(Container parent, CodeElement code, String description, String technology) {
         Component component = new Component();
-        component.setName(name);
-        component.setType(type);
+        component.setName(code.getName());
+        component.setType(code);
         component.setDescription(description);
         component.setTechnology(technology);
 

--- a/structurizr-core/test/unit/com/structurizr/analysis/SourceCodeComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/SourceCodeComponentFinderStrategyTests.java
@@ -26,11 +26,15 @@ public class SourceCodeComponentFinderStrategyTests {
         SoftwareSystem softwareSystem = model.addSoftwareSystem("Name", "Description");
         webApplication = softwareSystem.addContainer("Name", "Description", "Technology");
 
-        someComponent = webApplication.addComponent(
+        someComponent = webApplication.addComponentAndCode(
                 "SomeComponent",
                 "test.SourceCodeComponentFinderStrategy.SomeComponent",
+                "test.SourceCodeComponentFinderStrategy",
                 "", "");
-        someComponent.addSupportingType("test.SourceCodeComponentFinderStrategy.SomeComponentImpl");
+        someComponent.addSupportingType(
+                "SomeComponentImpl",
+                "test.SourceCodeComponentFinderStrategy.SomeComponentImpl",
+                "test.SourceCodeComponentFinderStrategy");
     }
 
     @Test

--- a/structurizr-core/test/unit/com/structurizr/analysis/SourceCodeComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/SourceCodeComponentFinderStrategyTests.java
@@ -31,7 +31,7 @@ public class SourceCodeComponentFinderStrategyTests {
                 "test.SourceCodeComponentFinderStrategy.SomeComponent",
                 "test.SourceCodeComponentFinderStrategy",
                 "", "");
-        someComponent.addSupportingType(
+        someComponent.addSupportingCode(
                 "SomeComponentImpl",
                 "test.SourceCodeComponentFinderStrategy.SomeComponentImpl",
                 "test.SourceCodeComponentFinderStrategy");

--- a/structurizr-core/test/unit/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategyTests.java
@@ -47,7 +47,7 @@ public class StructurizrAnnotationsComponentFinderStrategyTests {
         Component controller = webApplication.getComponentWithName("Controller");
         assertNotNull(controller);
         assertEquals("Controller", controller.getName());
-        assertEquals("test.StructurizrAnnotationsComponentFinderStrategy.Controller", controller.getType());
+        assertEquals("test.StructurizrAnnotationsComponentFinderStrategy.Controller", controller.getPrimaryCode().getType());
         assertEquals("Does something.", controller.getDescription());
         assertEquals(1, controller.getCode().size());
         assertCodeElementInComponent(controller, "test.StructurizrAnnotationsComponentFinderStrategy.Controller", CodeElementRole.Primary);
@@ -55,7 +55,7 @@ public class StructurizrAnnotationsComponentFinderStrategyTests {
         Component repository = webApplication.getComponentWithName("Repository");
         assertNotNull(repository);
         assertEquals("Repository", repository.getName());
-        assertEquals("test.StructurizrAnnotationsComponentFinderStrategy.Repository", repository.getType());
+        assertEquals("test.StructurizrAnnotationsComponentFinderStrategy.Repository", repository.getPrimaryCode().getType());
         assertEquals("Manages some data.", repository.getDescription());
         assertEquals(2, repository.getCode().size());
         assertCodeElementInComponent(repository, "test.StructurizrAnnotationsComponentFinderStrategy.Repository", CodeElementRole.Primary);

--- a/structurizr-core/test/unit/com/structurizr/analysis/TypeMatcherComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/TypeMatcherComponentFinderStrategyTests.java
@@ -41,14 +41,14 @@ public class TypeMatcherComponentFinderStrategyTests {
         Component myController = container.getComponentWithName("MyController");
         assertNotNull(myController);
         assertEquals("MyController", myController.getName());
-        assertEquals("test.TypeMatcherComponentFinderStrategy.MyController", myController.getType());
+        assertEquals("test.TypeMatcherComponentFinderStrategy.MyController", myController.getPrimaryCode().getType());
         assertEquals("Controller description", myController.getDescription());
         assertEquals("Controller technology", myController.getTechnology());
 
         Component myRepository = container.getComponentWithName("MyRepository");
         assertNotNull(myRepository);
         assertEquals("MyRepository", myRepository.getName());
-        assertEquals("test.TypeMatcherComponentFinderStrategy.MyRepository", myRepository.getType());
+        assertEquals("test.TypeMatcherComponentFinderStrategy.MyRepository", myRepository.getPrimaryCode().getType());
         assertEquals("Repository description", myRepository.getDescription());
         assertEquals("Repository technology", myRepository.getTechnology());
 

--- a/structurizr-core/test/unit/com/structurizr/analysis/TypeUtilsTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/TypeUtilsTests.java
@@ -18,51 +18,39 @@ import static org.junit.Assert.fail;
 
 public class TypeUtilsTests {
 
-    private static final TypeRepository types = new DefaultTypeRepository("", emptySet(), null);
-
-    @Test
-    public void test_getCategory_ReturnsNull_WhenTheSpecifiedTypeCouldNotBeFound() throws Exception {
-        assertNull(TypeUtils.getCategory(types, "com.company.app.Class"));
-    }
-
     @Test
     public void test_getCategory_ReturnsInterface_WhenTheSpecifiedTypeIsAnInterface() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeInterface");
+        TypeCategory typeCategory = TypeCategory.valueOf(Class.forName("test.TypeUtils.SomeInterface"));
         assertSame(TypeCategory.INTERFACE, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsAbstractClass_WhenTheSpecifiedTypeIsAnAbstractClass() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeAbstractClass");
+        TypeCategory typeCategory = TypeCategory.valueOf(Class.forName("test.TypeUtils.SomeAbstractClass"));
         assertSame(TypeCategory.ABSTRACT_CLASS, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsAbstractClass_WhenTheSpecifiedTypeIsAClass() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeClass");
+        TypeCategory typeCategory = TypeCategory.valueOf(Class.forName("test.TypeUtils.SomeClass"));
         assertSame(TypeCategory.CLASS, typeCategory);
     }
 
     @Test
     public void test_getCategory_ReturnsEnum_WhenTheSpecifiedTypeIsAnEnum() throws Exception {
-        TypeCategory typeCategory = TypeUtils.getCategory(types, "test.TypeUtils.SomeEnum");
+        TypeCategory typeCategory = TypeCategory.valueOf(Class.forName("test.TypeUtils.SomeEnum"));
         assertSame(TypeCategory.ENUM, typeCategory);
     }
 
     @Test
-    public void test_getVisibility_ReturnsNull_WhenTheSpecifiedTypeCouldNotBeFound() throws Exception {
-        assertNull(TypeUtils.getVisibility(types, "com.company.app.Class"));
-    }
-
-    @Test
     public void test_getVisibility_ReturnsPublic_WhenTheSpecifiedTypeIsPublic() throws Exception {
-        TypeVisibility typeCategory= TypeUtils.getVisibility(types, "test.TypeUtils.SomeInterface");
+        TypeVisibility typeCategory= TypeVisibility.valueOf(Class.forName("test.TypeUtils.SomeInterface"));
         assertSame(TypeVisibility.PUBLIC, typeCategory);
     }
 
     @Test
     public void test_getVisibility_ReturnsPackage_WhenTheSpecifiedTypeIsPackageScoped() throws Exception {
-        TypeVisibility typeCategory= TypeUtils.getVisibility(types, "test.TypeUtils.SomeClass");
+        TypeVisibility typeCategory= TypeVisibility.valueOf(Class.forName("test.TypeUtils.SomeClass"));
         assertSame(TypeVisibility.PACKAGE, typeCategory);
     }
 

--- a/structurizr-core/test/unit/com/structurizr/analysis/reflections/AbstractComponentFinderStrategyTests.java
+++ b/structurizr-core/test/unit/com/structurizr/analysis/reflections/AbstractComponentFinderStrategyTests.java
@@ -38,12 +38,12 @@ public class AbstractComponentFinderStrategyTests {
         Component aComponent = webApplication.getComponentWithName("AComponent");
         assertNotNull(aComponent);
         assertEquals("AComponent", aComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.cyclicDependency.AComponent", aComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.cyclicDependency.AComponent", aComponent.getPrimaryCode().getType());
 
         Component bComponent = webApplication.getComponentWithName("BComponent");
         assertNotNull(bComponent);
         assertEquals("BComponent", bComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.cyclicDependency.BComponent", bComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.cyclicDependency.BComponent", bComponent.getPrimaryCode().getType());
 
         assertEquals(1, aComponent.getRelationships().size());
         assertNotNull(aComponent.getRelationships().stream().filter(r -> r.getDestination() == bComponent).findFirst().get());
@@ -68,12 +68,12 @@ public class AbstractComponentFinderStrategyTests {
         Component someComponent = webApplication.getComponentWithName("SomeComponent");
         assertNotNull(someComponent);
         assertEquals("SomeComponent", someComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.dependenciesFromSuperClass.SomeComponent", someComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.dependenciesFromSuperClass.SomeComponent", someComponent.getPrimaryCode().getType());
 
         Component loggingComponent = webApplication.getComponentWithName("LoggingComponent");
         assertNotNull(loggingComponent);
         assertEquals("LoggingComponent", loggingComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.dependenciesFromSuperClass.LoggingComponent", loggingComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.dependenciesFromSuperClass.LoggingComponent", loggingComponent.getPrimaryCode().getType());
 
         assertEquals(1, someComponent.getRelationships().size());
         assertNotNull(someComponent.getRelationships().stream().filter(r -> r.getDestination() == loggingComponent).findFirst().get());
@@ -95,12 +95,12 @@ public class AbstractComponentFinderStrategyTests {
         Component someComponent = webApplication.getComponentWithName("SomeComponent");
         assertNotNull(someComponent);
         assertEquals("SomeComponent", someComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.featureinterface.SomeComponent", someComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.featureinterface.SomeComponent", someComponent.getPrimaryCode().getType());
 
         Component otherComponent = webApplication.getComponentWithName("OtherComponent");
         assertNotNull(otherComponent);
         assertEquals("OtherComponent", otherComponent.getName());
-        assertEquals("com.structurizr.analysis.reflections.featureinterface.OtherComponent", otherComponent.getType());
+        assertEquals("com.structurizr.analysis.reflections.featureinterface.OtherComponent", otherComponent.getPrimaryCode().getType());
 
         assertEquals(0, someComponent.getRelationships().size());
         assertEquals(0, otherComponent.getRelationships().size());

--- a/structurizr-core/test/unit/com/structurizr/io/json/JsonTests.java
+++ b/structurizr-core/test/unit/com/structurizr/io/json/JsonTests.java
@@ -42,7 +42,12 @@ public class JsonTests {
         webApplicationToDatabase.addTags("JDBC");
 
         Component componentA = webApplication.addComponent("ComponentA", "Description", "Technology A");
-        Component componentB = webApplication.addComponent("com.somecompany.system.ComponentB", "com.somecompany.system.ComponentBImpl", "Description", "Technology B");
+        Component componentB = webApplication.addComponentAndCode(
+                "ComponentB",
+                "com.somecompany.system.ComponentBImpl",
+                "com.somecompany.system",
+                "Description",
+                "Technology B");
         person.uses(componentA, "Uses");
         componentA.uses(componentB, "Uses");
         componentB.uses(database, "Reads from and writes to");

--- a/structurizr-core/test/unit/com/structurizr/model/CodeElementTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/CodeElementTests.java
@@ -8,21 +8,21 @@ public class CodeElementTests {
 
     @Test
     public void test_construction_WhenAFullyQualifiedNameIsSpecified() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertEquals("SomeComponent", codeElement.getName());
         assertEquals("com.structurizr.component.SomeComponent", codeElement.getType());
     }
 
     @Test
     public void test_construction_WhenAFullyQualifiedNameIsSpecifiedInTheDefaultPackage() {
-        CodeElement codeElement = new CodeElement("SomeComponent");
+        CodeElement codeElement = new CodeElement("SomeComponent", "SomeComponent", null);
         assertEquals("SomeComponent", codeElement.getName());
         assertEquals("SomeComponent", codeElement.getType());
     }
 
     @Test
     public void test_languageProperty() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertEquals("Java", codeElement.getLanguage());
 
         codeElement.setLanguage("Scala");
@@ -31,7 +31,7 @@ public class CodeElementTests {
 
     @Test
     public void test_categoryProperty() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertNull(codeElement.getCategory());
 
         codeElement.setCategory("class");
@@ -40,7 +40,7 @@ public class CodeElementTests {
 
     @Test
     public void test_visibilityProperty() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertNull(codeElement.getVisibility());
 
         codeElement.setVisibility("package");
@@ -49,65 +49,85 @@ public class CodeElementTests {
 
     @Test
     public void test_setUrl() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         codeElement.setUrl("https://structurizr.com");
         assertEquals("https://structurizr.com", codeElement.getUrl());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_setUrl_ThrowsAnIllegalArgumentException_WhenAnInvalidUrlIsSpecified() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         codeElement.setUrl("htt://blah");
     }
 
     @Test
     public void test_setUrl_DoesNothing_WhenANullUrlIsSpecified() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         codeElement.setUrl(null);
         assertNull(codeElement.getUrl());
     }
 
     @Test
     public void test_setUrl_DoesNothing_WhenAnEmptyUrlIsSpecified() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         codeElement.setUrl(" ");
         assertNull(codeElement.getUrl());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_construction_ThrowsAnIllegalArgumentException_WhenANullFullyQualifiedNameIsSpecified() {
-        new CodeElement(null);
+        new CodeElement(null, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_construction_ThrowsAnIllegalArgumentException_WhenAnEmptyFullyQualifiedNameIsSpecified() {
-        new CodeElement("  ");
+        new CodeElement("\t", " ", "        ");
     }
 
     @Test
     public void test_equals_ReturnsFalse_WhenComparedToNull() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertFalse(codeElement.equals(null));
     }
 
     @Test
     public void test_equals_ReturnsFalse_WhenComparedToDifferentTypeOfObject() {
-        CodeElement codeElement = new CodeElement("com.structurizr.component.SomeComponent");
+        CodeElement codeElement = newCodeElement();
         assertFalse(codeElement.equals("hello"));
     }
 
     @Test
     public void test_equals_ReturnsFalse_WhenComparedToAnotherCodeElementWithADifferentType() {
-        CodeElement codeElement1 = new CodeElement("com.structurizr.component.SomeComponent1");
-        CodeElement codeElement2 = new CodeElement("com.structurizr.component.SomeComponent2");
+        CodeElement codeElement1 = newCodeElement1();
+        CodeElement codeElement2 = newCodeElement2();
         assertFalse(codeElement1.equals(codeElement2));
     }
 
     @Test
     public void test_equals_ReturnsFalse_WhenComparedToAnotherCodeElementWithTheSameType() {
-        CodeElement codeElement1 = new CodeElement("com.structurizr.component.SomeComponent1");
-        CodeElement codeElement2 = new CodeElement("com.structurizr.component.SomeComponent1");
+        CodeElement codeElement1 = newCodeElement1();
+        CodeElement codeElement2 = newCodeElement1();
         assertTrue(codeElement1.equals(codeElement2));
     }
 
+    private CodeElement newCodeElement() {
+        return new CodeElement(
+                "SomeComponent",
+                "com.structurizr.component.SomeComponent",
+                "com.structurizr.component");
+    }
+
+    private CodeElement newCodeElement1() {
+        return new CodeElement(
+                "SomeComponent1",
+                "com.structurizr.component.SomeComponent1",
+                "com.structurizr.component");
+    }
+
+    private CodeElement newCodeElement2() {
+        return new CodeElement(
+                "SomeComponent2",
+                "com.structurizr.component.SomeComponent2",
+                "com.structurizr.component");
+    }
 }

--- a/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
@@ -61,7 +61,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     public void test_getPackage_ReturnsNull_WhenNoTypeHasBeenSet() {
         Component component = new Component();
         assertNull(component.getType());
-        assertNull(component.getPackage());
+        assertNull(component.getPrimaryCode());
     }
 
     @Test
@@ -71,13 +71,13 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
                 ComponentTests.class.getSimpleName(),
                 ComponentTests.class.getCanonicalName(),
                 ComponentTests.class.getPackage().getName());
-        assertEquals("com.structurizr.model", component.getPackage());
+        assertEquals("com.structurizr.model", component.getPrimaryCode().getNamespace());
     }
 
     @Test
     public void test_getPackage_ReturnsThePackageName_WhenATypeHasNotBeenSet() {
         Component component = new Component();
-        assertNull(component.getPackage());
+        assertNull(component.getPrimaryCode());
     }
 
     @Test

--- a/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
@@ -60,7 +60,6 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_getPackage_ReturnsNull_WhenNoTypeHasBeenSet() {
         Component component = new Component();
-        assertNull(component.getType());
         assertNull(component.getPrimaryCode());
     }
 

--- a/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
@@ -67,7 +67,10 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_getPackage_ReturnsThePackageName_WhenATypeHasBeenSet() {
         Component component = new Component();
-        component.setType(ComponentTests.class.getCanonicalName());
+        component.setType(
+                ComponentTests.class.getSimpleName(),
+                ComponentTests.class.getCanonicalName(),
+                ComponentTests.class.getPackage().getName());
         assertEquals("com.structurizr.model", component.getPackage());
     }
 
@@ -90,17 +93,20 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     public void test_setType_ThrowsAnExceptionWhenPassedNull() {
         Component component = new Component();
         try {
-            component.setType(null);
+            component.setType(null, null, null);
             fail();
         } catch (IllegalArgumentException iae) {
-            assertEquals("A fully qualified name must be provided.", iae.getMessage());
+            assertEquals("A name must be provided.", iae.getMessage());
         }
     }
 
     @Test
     public void test_setType_AddsAPrimaryCodeElement_WhenPassedAFullyQualifiedTypeName() {
         Component component = new Component();
-        component.setType("com.structurizr.web.HomePageController");
+        component.setType(
+                "HomePageController",
+                "com.structurizr.web.HomePageController",
+                "com.structurizr.web");
 
         Set<CodeElement> codeElements = component.getCode();
         assertEquals(1, codeElements.size());
@@ -113,8 +119,14 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_setType_OverwritesThePrimaryCodeElement_WhenCalledMoreThanOnce() {
         Component component = new Component();
-        component.setType("com.structurizr.web.HomePageController");
-        component.setType("com.structurizr.web.SomeOtherController");
+        component.setType(
+                "HomePageController",
+                "com.structurizr.web.HomePageController",
+                "com.structurizr.web");
+        component.setType(
+                "SomeOtherController",
+                "com.structurizr.web.SomeOtherController",
+                "com.structurizr.web");
 
         Set<CodeElement> codeElements = component.getCode();
         assertEquals(1, codeElements.size());
@@ -129,17 +141,20 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     public void test_addSupportingType_ThrowsAnExceptionWhenPassedNull() {
         Component component = new Component();
         try {
-            component.addSupportingType(null);
+            component.addSupportingType(null, null, null);
             fail();
         } catch (IllegalArgumentException iae) {
-            assertEquals("A fully qualified name must be provided.", iae.getMessage());
+            assertEquals("A name must be provided.", iae.getMessage());
         }
     }
 
     @Test
     public void test_addSupportingType_AddsASupportingCodeElement_WhenPassedAFullyQualifiedTypeName() {
         Component component = new Component();
-        component.addSupportingType("com.structurizr.web.HomePageViewModel");
+        component.addSupportingType(
+                "HomePageViewModel",
+                "com.structurizr.web.HomePageViewModel",
+                "com.structurizr.web");
 
         Set<CodeElement> codeElements = component.getCode();
         assertEquals(1, codeElements.size());

--- a/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
@@ -128,7 +128,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     public void test_addSupportingType_ThrowsAnExceptionWhenPassedNull() {
         Component component = new Component();
         try {
-            component.addSupportingType(null, null, null);
+            component.addSupportingCode(null, null, null);
             fail();
         } catch (IllegalArgumentException iae) {
             assertEquals("A name must be provided.", iae.getMessage());
@@ -138,7 +138,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_addSupportingType_AddsASupportingCodeElement_WhenPassedAFullyQualifiedTypeName() {
         Component component = new Component();
-        component.addSupportingType(
+        component.addSupportingCode(
                 "HomePageViewModel",
                 "com.structurizr.web.HomePageViewModel",
                 "com.structurizr.web");

--- a/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ComponentTests.java
@@ -66,10 +66,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_getPackage_ReturnsThePackageName_WhenATypeHasBeenSet() {
         Component component = new Component();
-        component.setType(
-                ComponentTests.class.getSimpleName(),
-                ComponentTests.class.getCanonicalName(),
-                ComponentTests.class.getPackage().getName());
+        component.setPrimaryCode(new CodeElement(ComponentTests.class.getSimpleName(), ComponentTests.class.getCanonicalName(), ComponentTests.class.getPackage().getName()));
         assertEquals("com.structurizr.model", component.getPrimaryCode().getNamespace());
     }
 
@@ -92,7 +89,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     public void test_setType_ThrowsAnExceptionWhenPassedNull() {
         Component component = new Component();
         try {
-            component.setType(null, null, null);
+            component.setPrimaryCode(new CodeElement(null, null, null));
             fail();
         } catch (IllegalArgumentException iae) {
             assertEquals("A name must be provided.", iae.getMessage());
@@ -102,10 +99,7 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_setType_AddsAPrimaryCodeElement_WhenPassedAFullyQualifiedTypeName() {
         Component component = new Component();
-        component.setType(
-                "HomePageController",
-                "com.structurizr.web.HomePageController",
-                "com.structurizr.web");
+        component.setPrimaryCode(new CodeElement("HomePageController", "com.structurizr.web.HomePageController", "com.structurizr.web"));
 
         Set<CodeElement> codeElements = component.getCode();
         assertEquals(1, codeElements.size());
@@ -118,14 +112,8 @@ public class ComponentTests extends AbstractWorkspaceTestBase {
     @Test
     public void test_setType_OverwritesThePrimaryCodeElement_WhenCalledMoreThanOnce() {
         Component component = new Component();
-        component.setType(
-                "HomePageController",
-                "com.structurizr.web.HomePageController",
-                "com.structurizr.web");
-        component.setType(
-                "SomeOtherController",
-                "com.structurizr.web.SomeOtherController",
-                "com.structurizr.web");
+        component.setPrimaryCode(new CodeElement("HomePageController", "com.structurizr.web.HomePageController", "com.structurizr.web"));
+        component.setPrimaryCode(new CodeElement("SomeOtherController", "com.structurizr.web.SomeOtherController", "com.structurizr.web"));
 
         Set<CodeElement> codeElements = component.getCode();
         assertEquals(1, codeElements.size());

--- a/structurizr-core/test/unit/com/structurizr/model/MessageDigestIdGeneratorTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/MessageDigestIdGeneratorTests.java
@@ -18,10 +18,10 @@ import org.junit.Test;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 
 public class MessageDigestIdGeneratorTests {
 
@@ -57,7 +57,7 @@ public class MessageDigestIdGeneratorTests {
     public void writeAndRead() throws WorkspaceWriterException, WorkspaceReaderException {
         final MessageDigestIdGenerator ids = MessageDigestIdGenerator.getInstance("SHA-512");
 
-        final String specificId = "80cccbdd44024c1497a546b84b34be72da3829bf19818ce81b94dc6ecd59328b6b675679f952d95c8b402832306d1b9cbb754bd810759619c8b73b378a676609";
+        final String specificId = "a5341244d7a6fa9cde9edb2794587877704edeae985ca56bd9b3c71404ecb37d148a61eb69be4c113f516f04f5ecff7f936487880277b03d79e8689daae3c262";
 
         Workspace workspace1 = createWorkspace(ids);
 
@@ -74,7 +74,7 @@ public class MessageDigestIdGeneratorTests {
         Workspace workspace2 = jsonReader.read(stringReader);
 
         assertEquals(
-                "/My Software System/Web Application/com.somecompany.system.ComponentB",
+                "/My Software System/Web Application/ComponentB",
                 workspace2.getModel().getElement(specificId).getCanonicalName());
     }
 
@@ -114,7 +114,11 @@ public class MessageDigestIdGeneratorTests {
         webApplicationToDatabase.addTags("JDBC");
 
         Component componentA = webApplication.addComponent("ComponentA", "Description", "Technology A");
-        Component componentB = webApplication.addComponent("com.somecompany.system.ComponentB", "com.somecompany.system.ComponentBImpl", "Description", "Technology B");
+        Component componentB = webApplication.addComponentAndCode(
+                "ComponentB",
+                "com.somecompany.system.ComponentBImpl",
+                "com.somecompany.system",
+                "Description", "Technology B");
         person.uses(componentA, "Uses");
         componentA.uses(componentB, "Uses");
         componentB.uses(database, "Reads from and writes to");

--- a/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
+++ b/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
@@ -61,7 +61,7 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
 
                     if (foundInterface) {
                         // the primary component type is now an interface, so add the type we originally found as a supporting type
-                        component.addSupportingType(annotatedType);
+                        component.addSupportingCode(annotatedType);
                     }
                 }
             }

--- a/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
+++ b/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
@@ -28,8 +28,9 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
         for (Class<?> annotatedType : annotatedTypes) {
             if (annotatedType.isInterface()) {
                 // the annotated type is an interface, so we're done
-                components.add(getComponentFinder().getContainer().addComponent(
-                        annotatedType.getSimpleName(), annotatedType.getCanonicalName(), "", technology));
+                components.add(getComponentFinder()
+                        .getContainer()
+                        .addComponentAndCode(annotatedType, "", technology));
             } else {
                 // The Spring @Component, @Service and @Repository annotations are typically used to annotate implementation
                 // classes, but we really want to find the interface type and use that to represent the component. Why?
@@ -47,7 +48,6 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
                         if (componentName.startsWith(interfaceName) || // <InterfaceName><***>
                                 componentName.endsWith(interfaceName) ||   // <***><InterfaceName>
                                 componentName.contains(interfaceName)) {   // <***><InterfaceName><***>
-                            componentName = interfaceName;
                             componentType = interfaceType;
                             foundInterface = true;
                             break;
@@ -56,12 +56,12 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
                 }
 
                 if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                    Component component = getComponentFinder().getContainer().addComponent(componentName, componentType, "", technology);
+                    Component component = getComponentFinder().getContainer().addComponentAndCode(componentType, "", technology);
                     components.add(component);
 
                     if (foundInterface) {
                         // the primary component type is now an interface, so add the type we originally found as a supporting type
-                        component.addSupportingType(annotatedType.getCanonicalName());
+                        component.addSupportingType(annotatedType);
                     }
                 }
             }

--- a/structurizr-spring/src/com/structurizr/analysis/SpringRepositoryComponentFinderStrategy.java
+++ b/structurizr-spring/src/com/structurizr/analysis/SpringRepositoryComponentFinderStrategy.java
@@ -48,9 +48,8 @@ public final class SpringRepositoryComponentFinderStrategy extends AbstractSprin
 
         for (Class<?> componentType : componentTypes) {
             if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                componentsFound.add(getComponentFinder().getContainer().addComponent(
-                        componentType.getSimpleName(),
-                        componentType.getCanonicalName(),
+                componentsFound.add(getComponentFinder().getContainer().addComponentAndCode(
+                        componentType,
                         "",
                         SPRING_REPOSITORY));
             }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/AbstractSpringComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/AbstractSpringComponentFinderStrategyTests.java
@@ -28,10 +28,10 @@ public class AbstractSpringComponentFinderStrategyTests {
         assertEquals(2, container.getComponents().size());
 
         Component component = container.getComponentWithName("SomeController");
-        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeController", component.getType());
+        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeController", component.getPrimaryCode().getType());
 
         component = container.getComponentWithName("SomePublicRepository");
-        assertEquals("test.AbstractSpringComponentFinderStrategy.SomePublicRepository", component.getType());
+        assertEquals("test.AbstractSpringComponentFinderStrategy.SomePublicRepository", component.getPrimaryCode().getType());
     }
 
     @Test
@@ -53,13 +53,13 @@ public class AbstractSpringComponentFinderStrategyTests {
         assertEquals(3, container.getComponents().size());
 
         Component component = container.getComponentWithName("SomeController");
-        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeController", component.getType());
+        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeController", component.getPrimaryCode().getType());
 
         component = container.getComponentWithName("SomePublicRepository");
-        assertEquals("test.AbstractSpringComponentFinderStrategy.SomePublicRepository", component.getType());
+        assertEquals("test.AbstractSpringComponentFinderStrategy.SomePublicRepository", component.getPrimaryCode().getType());
 
         component = container.getComponentWithName("SomeNonPublicRepository");
-        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeNonPublicRepository", component.getType());
+        assertEquals("test.AbstractSpringComponentFinderStrategy.SomeNonPublicRepository", component.getPrimaryCode().getType());
     }
 
 }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringComponentComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringComponentComponentFinderStrategyTests.java
@@ -27,7 +27,7 @@ public class SpringComponentComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeComponent");
-        assertEquals("test.SpringComponentComponentFinderStrategy.SomeComponent", component.getType());
+        assertEquals("test.SpringComponentComponentFinderStrategy.SomeComponent", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring Component", component.getTechnology());
     }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringComponentFinderStrategyTests.java
@@ -37,19 +37,19 @@ public class SpringComponentFinderStrategyTests {
         Component someMvcController = webApplication.getComponentWithName("SomeController");
         assertNotNull(someMvcController);
         assertEquals("SomeController", someMvcController.getName());
-        assertEquals("com.structurizr.analysis.myapp.web.SomeController", someMvcController.getType());
+        assertEquals("com.structurizr.analysis.myapp.web.SomeController", someMvcController.getPrimaryCode().getType());
         assertEquals(1, someMvcController.getCode().size());
 
         Component someRestController = webApplication.getComponentWithName("SomeApiController");
         assertNotNull(someRestController);
         assertEquals("SomeApiController", someRestController.getName());
-        assertEquals("com.structurizr.analysis.myapp.api.SomeApiController", someRestController.getType());
+        assertEquals("com.structurizr.analysis.myapp.api.SomeApiController", someRestController.getPrimaryCode().getType());
         assertEquals(1, someRestController.getCode().size());
 
         Component someService = webApplication.getComponentWithName("SomeService");
         assertNotNull(someService);
         assertEquals("SomeService", someService.getName());
-        assertEquals("com.structurizr.analysis.myapp.service.SomeService", someService.getType());
+        assertEquals("com.structurizr.analysis.myapp.service.SomeService", someService.getPrimaryCode().getType());
         assertEquals(2, someService.getCode().size());
         assertCodeElementInComponent(someService, "com.structurizr.analysis.myapp.service.SomeService", CodeElementRole.Primary);
         assertCodeElementInComponent(someService, "com.structurizr.analysis.myapp.service.SomeServiceImpl", CodeElementRole.Supporting);
@@ -57,7 +57,7 @@ public class SpringComponentFinderStrategyTests {
         Component someRepository = webApplication.getComponentWithName("SomeRepository");
         assertNotNull(someRepository);
         assertEquals("SomeRepository", someRepository.getName());
-        assertEquals("com.structurizr.analysis.myapp.data.SomeRepository", someRepository.getType());
+        assertEquals("com.structurizr.analysis.myapp.data.SomeRepository", someRepository.getPrimaryCode().getType());
         assertEquals(2, someRepository.getCode().size());
         assertCodeElementInComponent(someService, "com.structurizr.analysis.myapp.data.SomeRepository", CodeElementRole.Primary);
         assertCodeElementInComponent(someService, "com.structurizr.analysis.myapp.data.JdbcSomeRepository", CodeElementRole.Supporting);
@@ -66,7 +66,7 @@ public class SpringComponentFinderStrategyTests {
         Component someOtherRepository = webApplication.getComponentWithName("SomeOtherRepository");
         assertNotNull(someOtherRepository);
         assertEquals("SomeOtherRepository", someOtherRepository.getName());
-        assertEquals("com.structurizr.analysis.myapp.data.SomeOtherRepository", someOtherRepository.getType());
+        assertEquals("com.structurizr.analysis.myapp.data.SomeOtherRepository", someOtherRepository.getPrimaryCode().getType());
 
         assertEquals(1, someMvcController.getRelationships().size());
         Relationship relationship = someMvcController.getRelationships().iterator().next();

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringMvcControllerComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringMvcControllerComponentFinderStrategyTests.java
@@ -27,7 +27,7 @@ public class SpringMvcControllerComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeController");
-        assertEquals("test.SpringMvcControllerComponentFinderStrategy.SomeController", component.getType());
+        assertEquals("test.SpringMvcControllerComponentFinderStrategy.SomeController", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring MVC Controller", component.getTechnology());
     }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringRepositoryComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringRepositoryComponentFinderStrategyTests.java
@@ -27,7 +27,7 @@ public class SpringRepositoryComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeRepository");
-        assertEquals("test.SpringRepositoryComponentFinderStrategy.annotation.SomeRepository", component.getType());
+        assertEquals("test.SpringRepositoryComponentFinderStrategy.annotation.SomeRepository", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring Repository", component.getTechnology());
     }
@@ -48,7 +48,7 @@ public class SpringRepositoryComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeJpaRepository");
-        assertEquals("test.SpringRepositoryComponentFinderStrategy.jpaRepository.SomeJpaRepository", component.getType());
+        assertEquals("test.SpringRepositoryComponentFinderStrategy.jpaRepository.SomeJpaRepository", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring Repository", component.getTechnology());
     }
@@ -69,7 +69,7 @@ public class SpringRepositoryComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeCrudRepository");
-        assertEquals("test.SpringRepositoryComponentFinderStrategy.crudRepository.SomeCrudRepository", component.getType());
+        assertEquals("test.SpringRepositoryComponentFinderStrategy.crudRepository.SomeCrudRepository", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring Repository", component.getTechnology());
     }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringRestControllerComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringRestControllerComponentFinderStrategyTests.java
@@ -27,7 +27,7 @@ public class SpringRestControllerComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeController");
-        assertEquals("test.SpringRestControllerComponentFinderStrategy.SomeController", component.getType());
+        assertEquals("test.SpringRestControllerComponentFinderStrategy.SomeController", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring REST Controller", component.getTechnology());
     }

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringServiceComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringServiceComponentFinderStrategyTests.java
@@ -27,7 +27,7 @@ public class SpringServiceComponentFinderStrategyTests {
 
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeService");
-        assertEquals("test.SpringServiceComponentFinderStrategy.SomeService", component.getType());
+        assertEquals("test.SpringServiceComponentFinderStrategy.SomeService", component.getPrimaryCode().getType());
         assertEquals("", component.getDescription());
         assertEquals("Spring Service", component.getTechnology());
     }


### PR DESCRIPTION
While working on #73 I was surprised to find that Component.getPackage() was querying the type system directly rather than returning a property. After digging around I was also surprised to find that getPackage() was a method of Component rather than CodeElement, and similarly getType(). I decided to put this PR together to address both of these (figured that getNamespace() felt a more language agnostic term than getPackage() - happy to switch it back if preferred).

This pull request is mostly a series of refactorings:
* SupportingTypesStrategy.findSupportingTypes() returns Class<?>
* CodeElement constructed from Class<?> and has namespace property
* Simplified TypeUtils, TypeCategory, TypeVisibility
* Removed Component.getPackage() in favour of CodeElement.getNamespace()
* Removed Component.getType() in favour of Component.getPrimaryCode().getType()
* Replaced Component.setType() with Component.setPrimaryCode()
* Renamed Component.addSupportingType() to Component.addSupportingCode()