### PR TITLE
Adding Model.removeRelationship() and ContainerInstance.removeEfferentRelationshipWith()

### DIFF
--- a/structurizr-core/src/com/structurizr/model/ContainerInstance.java
+++ b/structurizr-core/src/com/structurizr/model/ContainerInstance.java
@@ -125,6 +125,19 @@ public final class ContainerInstance extends Element {
             throw new IllegalArgumentException("The destination of a relationship must be specified.");
         }
     }
+    
+    /**
+     * Remove the efferent (outgoing) relationship with the specified {@link ContainerInstance}.
+     *
+     * @param destination the {@link ContainerInstance} to which the relationship should be removed
+     * @return a Relationship object if an efferent relationship existed, null otherwise
+     */
+    public Relationship removeEfferentRelationshipWith(ContainerInstance destination) {
+        final Relationship relationship = getEfferentRelationshipWith(destination);
+        if(relationship != null)
+            getModel().removeRelationship(relationship);
+        return relationship;
+    }
 
     /**
      * Gets the set of health checks associated with this container instance.

--- a/structurizr-core/src/com/structurizr/model/Element.java
+++ b/structurizr-core/src/com/structurizr/model/Element.java
@@ -219,6 +219,10 @@ public abstract class Element extends Taggable {
     void addRelationship(Relationship relationship) {
         relationships.add(relationship);
     }
+    
+    void removeRelationship(Relationship relationship) {
+        relationships.remove(relationship);
+    }
 
     @Override
     public String toString() {

--- a/structurizr-core/src/com/structurizr/model/Model.java
+++ b/structurizr-core/src/com/structurizr/model/Model.java
@@ -199,6 +199,12 @@ public final class Model {
         idGenerator.found(relationship.getId());
     }
 
+    /** Remove existing {@link Relationship} */
+    public void removeRelationship(Relationship relationship) {
+        relationshipsById.remove(relationship.getId());
+        relationship.getSource().removeRelationship(relationship);
+    }
+
     /**
      * Gets the set of all elements in this model.
      *

--- a/structurizr-core/test/unit/com/structurizr/model/ContainerInstanceTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ContainerInstanceTests.java
@@ -121,5 +121,19 @@ public class ContainerInstanceTests extends AbstractWorkspaceTestBase {
         assertEquals("http://localhost:8080", healthCheck.getUrl());
         assertEquals(1, instance.getHealthChecks().size());
     }
+    
+    @Test
+    public void test_removeEfferentRelationshipWith() {
+        Container frontEnd = softwareSystem.addContainer("Frontend", "", "");
+        Container backend = softwareSystem.addContainer("Backend", "Multi instance backend", "");
+        frontEnd.uses(backend, "");
+
+        final ContainerInstance backend1 = model.addContainerInstance(backend);
+        final ContainerInstance backend2 = model.addContainerInstance(backend);
+        final ContainerInstance instance = model.addContainerInstance(frontEnd);
+        assertEquals(2, instance.getRelationships().size());
+        instance.removeEfferentRelationshipWith(backend2);
+        assertEquals(1, instance.getRelationships().size());
+    }
 
 }


### PR DESCRIPTION
I found myself needing to correct Structurizrs assumption that all container instances have a relationship to all instances of a container they are using. Could this be integrated into the core version...?