### PR TITLE
Avoid failures when re-finding the same component #83

### DIFF
--- a/structurizr-analysis/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -2,6 +2,7 @@ package com.structurizr.analysis;
 
 import com.structurizr.model.CodeElement;
 import com.structurizr.model.Component;
+import com.structurizr.model.Container;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -163,11 +164,14 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
         Set<Class<?>> componentTypes = findTypesAnnotatedWith(type);
         for (Class<?> componentType : componentTypes) {
             if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                components.add(getComponentFinder().getContainer().addComponent(
+                final Container container = getComponentFinder().getContainer();
+                if (container.getComponentWithName(componentType.getSimpleName()) == null) {
+                    components.add(container.addComponent(
                         componentType.getSimpleName(),
                         componentType.getCanonicalName(),
                         "",
                         technology));
+                }
             }
         }
 

--- a/structurizr-analysis/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategy.java
@@ -32,17 +32,20 @@ public class StructurizrAnnotationsComponentFinderStrategy extends AbstractCompo
     @Override
     protected Set<Component> doFindComponents() {
         Set<Component> components = new HashSet<>();
+        Container container = getComponentFinder().getContainer();
 
         // find all types that have been annotated @Component
         Set<Class<?>> componentTypes = findTypesAnnotatedWith(com.structurizr.annotation.Component.class);
         for (Class<?> componentType : componentTypes) {
-            Component component = getComponentFinder().getContainer().addComponent(
-                    componentType.getSimpleName(),
-                    componentType,
-                    componentType.getAnnotation(com.structurizr.annotation.Component.class).description(),
-                    componentType.getAnnotation(com.structurizr.annotation.Component.class).technology()
-            );
-            components.add(component);
+            if (container.getComponentWithName(componentType.getSimpleName()) == null) {
+                Component component = container.addComponent(
+                        componentType.getSimpleName(),
+                        componentType,
+                        componentType.getAnnotation(com.structurizr.annotation.Component.class).description(),
+                        componentType.getAnnotation(com.structurizr.annotation.Component.class).technology()
+                );
+                components.add(component);
+            }
         }
 
         return components;

--- a/structurizr-analysis/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java
@@ -1,6 +1,7 @@
 package com.structurizr.analysis;
 
 import com.structurizr.model.Component;
+import com.structurizr.model.Container;
 
 import java.util.*;
 
@@ -24,12 +25,15 @@ public class TypeMatcherComponentFinderStrategy extends AbstractComponentFinderS
         for (Class type : types) {
             for (TypeMatcher typeMatcher : typeMatchers) {
                 if (typeMatcher.matches(type)) {
-                    Component component = getComponentFinder().getContainer().addComponent(
+                    final Container container = getComponentFinder().getContainer();
+                    if (container.getComponentWithName(type.getSimpleName()) == null) {
+                        Component component = container.addComponent(
                             type.getSimpleName(),
                             type.getCanonicalName(),
                             typeMatcher.getDescription(),
                             typeMatcher.getTechnology());
-                    components.add(component);
+                        components.add(component);
+                    }
                 }
             }
         }

--- a/structurizr-analysis/test/unit/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategyTests.java
+++ b/structurizr-analysis/test/unit/com/structurizr/analysis/StructurizrAnnotationsComponentFinderStrategyTests.java
@@ -38,6 +38,9 @@ public class StructurizrAnnotationsComponentFinderStrategyTests {
                 new StructurizrAnnotationsComponentFinderStrategy()
         );
         componentFinder.findComponents();
+
+        // finding the components again should be idempotent
+        componentFinder.findComponents();
     }
 
     @Test

--- a/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
+++ b/structurizr-spring/src/com/structurizr/analysis/AbstractSpringComponentFinderStrategy.java
@@ -1,6 +1,7 @@
 package com.structurizr.analysis;
 
 import com.structurizr.model.Component;
+import com.structurizr.model.Container;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
@@ -24,12 +25,16 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
     protected Set<Component> findInterfacesForImplementationClassesWithAnnotation(Class<? extends Annotation> type, String technology) {
         Set<Component> components = new HashSet<>();
 
+        Container container = getComponentFinder().getContainer();
         Set<Class<?>> annotatedTypes = findTypesAnnotatedWith(type);
         for (Class<?> annotatedType : annotatedTypes) {
-            if (annotatedType.isInterface()) {
+            if (container.getComponentWithName(annotatedType.getSimpleName()) != null) {
+              continue;
+            }
+            else if (annotatedType.isInterface()) {
                 // the annotated type is an interface, so we're done
-                components.add(getComponentFinder().getContainer().addComponent(
-                        annotatedType.getSimpleName(), annotatedType.getCanonicalName(), "", technology));
+                components.add(container.addComponent(
+                    annotatedType.getSimpleName(), annotatedType.getCanonicalName(), "", technology));
             } else {
                 // The Spring @Component, @Service and @Repository annotations are typically used to annotate implementation
                 // classes, but we really want to find the interface type and use that to represent the component. Why?
@@ -56,8 +61,8 @@ public abstract class AbstractSpringComponentFinderStrategy extends AbstractComp
                 }
 
                 if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                    Component component = getComponentFinder().getContainer().addComponent(componentName, componentType, "", technology);
-                    components.add(component);
+                  Component component = container.addComponent(componentName, componentType, "", technology);
+                  components.add(component);
 
                     if (foundInterface) {
                         // the primary component type is now an interface, so add the type we originally found as a supporting type

--- a/structurizr-spring/src/com/structurizr/analysis/SpringRepositoryComponentFinderStrategy.java
+++ b/structurizr-spring/src/com/structurizr/analysis/SpringRepositoryComponentFinderStrategy.java
@@ -1,6 +1,7 @@
 package com.structurizr.analysis;
 
 import com.structurizr.model.Component;
+import com.structurizr.model.Container;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
@@ -48,11 +49,14 @@ public final class SpringRepositoryComponentFinderStrategy extends AbstractSprin
 
         for (Class<?> componentType : componentTypes) {
             if (!includePublicTypesOnly || Modifier.isPublic(componentType.getModifiers())) {
-                componentsFound.add(getComponentFinder().getContainer().addComponent(
+                final Container container = getComponentFinder().getContainer();
+                if (container.getComponentWithName(componentType.getSimpleName()) == null) {
+                    componentsFound.add(container.addComponent(
                         componentType.getSimpleName(),
                         componentType.getCanonicalName(),
                         "",
                         SPRING_REPOSITORY));
+                }
             }
         }
 

--- a/structurizr-spring/test/unit/com/structurizr/analysis/AbstractSpringComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/AbstractSpringComponentFinderStrategyTests.java
@@ -27,6 +27,11 @@ public class AbstractSpringComponentFinderStrategyTests {
 
         assertEquals(2, container.getComponents().size());
 
+        // finding the components again should be idempotent
+        componentFinder.findComponents();
+
+        assertEquals(2, container.getComponents().size());
+
         Component component = container.getComponentWithName("SomeController");
         assertEquals("test.AbstractSpringComponentFinderStrategy.SomeController", component.getType().getType());
 
@@ -48,6 +53,11 @@ public class AbstractSpringComponentFinderStrategyTests {
                 "test.AbstractSpringComponentFinderStrategy",
                 springComponentFinderStrategy
         );
+        componentFinder.findComponents();
+
+        assertEquals(3, container.getComponents().size());
+
+        // finding the components again should be idempotent
         componentFinder.findComponents();
 
         assertEquals(3, container.getComponents().size());

--- a/structurizr-spring/test/unit/com/structurizr/analysis/SpringRepositoryComponentFinderStrategyTests.java
+++ b/structurizr-spring/test/unit/com/structurizr/analysis/SpringRepositoryComponentFinderStrategyTests.java
@@ -25,6 +25,9 @@ public class SpringRepositoryComponentFinderStrategyTests {
         );
         componentFinder.findComponents();
 
+        // finding the components again should be idempotent
+        componentFinder.findComponents();
+
         assertEquals(1, container.getComponents().size());
         Component component = container.getComponentWithName("SomeRepository");
         assertEquals("test.SpringRepositoryComponentFinderStrategy.annotation.SomeRepository", component.getType().getType());


### PR DESCRIPTION
The model has already been updated to block duplicate components from being allowed, this change modifies the analysis code blocks duplicate components from being found in the first place. This means that two different strategies can find the same class without attempting to add a duplicate component.

Tests approximate this by proving that the same strategy run twice is idempotent rather than throwing e.g. `java.lang.IllegalArgumentException: A component named 'ProtectedResources' already exists for this container`