### PR TITLE
TypeRepository should be public

### DIFF
--- a/structurizr-analysis/src/com/structurizr/analysis/TypeRepository.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/TypeRepository.java
@@ -5,7 +5,7 @@ import java.util.Set;
 /**
  * This represents an abstraction for a repository of type information.
  */
-interface TypeRepository {
+public interface TypeRepository {
 
     /**
      * Gets the package that this type repository is associated with scanning.


### PR DESCRIPTION
Turns out that implementing a custom `SupportingTypesStrategy` is difficult without access to the `TypeRepository`. Currently working around this by putting my custom implementations into a `com.structurizr.analysis` package but making the interface public should be a far cleaner solution.

(I haven't checked for other interfaces or classes that might benefit from the same change)