### PR TITLE
ComponentFinderStrategy instances share a single TypeRepository

### DIFF
--- a/structurizr-analysis/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/AbstractComponentFinderStrategy.java
@@ -43,13 +43,12 @@ public abstract class AbstractComponentFinderStrategy implements ComponentFinder
     }
 
     protected TypeRepository getTypeRepository() {
-        return typeRepository;
+        return componentFinder.getTypeRepository();
     }
 
     @Override
     public void beforeFindComponents() {
-        typeRepository = new DefaultTypeRepository(componentFinder.getPackageName(), componentFinder.getExclusions(), componentFinder.getUrlClassLoader());
-        supportingTypesStrategies.forEach(sts -> sts.setTypeRepository(typeRepository));
+        supportingTypesStrategies.forEach(sts -> sts.setTypeRepository(getTypeRepository()));
     }
 
     @Override

--- a/structurizr-analysis/src/com/structurizr/analysis/ComponentFinder.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/ComponentFinder.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 public class ComponentFinder {
 
     private URLClassLoader urlClassLoader;
+    private TypeRepository typeRepository;
     private Container container;
     private String packageName;
 
@@ -142,5 +143,24 @@ public class ComponentFinder {
      */
     public URLClassLoader getUrlClassLoader() {
         return urlClassLoader;
+    }
+
+    /**
+     * Gets the type repository used to analyse java classes
+     * @param typeRepository the type repository to use when analysing
+     */
+    public void setTypeRepository(TypeRepository typeRepository) {
+        this.typeRepository = typeRepository;
+    }
+
+    /**
+     * Gets the type repository used to analyse java classes
+     * @return the type supplied type repository, or a default implementation
+     */
+    public TypeRepository getTypeRepository() {
+        if (typeRepository == null) {
+            typeRepository = new DefaultTypeRepository(getPackageName(), getExclusions(), getUrlClassLoader());
+        }
+        return typeRepository;
     }
 }


### PR DESCRIPTION
Multiple `ComponentFinderStrategy` instances now share a single `TypeRepository` to avoid rescanning. Should speed things up with bigger codebases, especially using `SpringComponentFinderStrategy` which now uses one shared instance rather than 5!