### PR TITLE
Upgrade httpclient5 to 5.0-beta4 which includes a fix for proxy conne…

### DIFF
--- a/structurizr-client/build.gradle
+++ b/structurizr-client/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.0'
 
-    compile 'org.apache.httpcomponents.client5:httpclient5:5.0-beta2'
+    compile 'org.apache.httpcomponents.client5:httpclient5:5.0-beta4'
 
     compile 'javax.xml.bind:jaxb-api:2.3.0'
 


### PR DESCRIPTION
Upgrade httpclient5 to 5.0-beta4 which includes a fix for proxy connections

The following behaviour has been fixed
1) Specify a proxy via https.proxyHost/https.proxyPort JVM properties
2) Execute for example a HTTP GET via httpClient.execute(...)
3) HttpClient will throw java.lang.IllegalArgumentException: Inet address must not be null is thrown (see stacktrace below)

See also https://issues.apache.org/jira/browse/HTTPCLIENT-1959

Fixes #115 