### PR TITLE
Fix ordering of sequences when more than 9 relationships

### DIFF
--- a/structurizr-core/src/com/structurizr/view/RelationshipView.java
+++ b/structurizr-core/src/com/structurizr/view/RelationshipView.java
@@ -18,7 +18,7 @@ public final class RelationshipView {
     private Relationship relationship;
     private String id;
     private String description;
-    private String order;
+    private Integer order;
     private Collection<Vertex> vertices = new LinkedList<>();
 
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
@@ -87,18 +87,18 @@ public final class RelationshipView {
     /**
      * Gets the order of this relationship (used in dynamic views only; e.g. 1.0, 1.1, 2.0, etc).
      *
-     * @return  the order, as a String
+     * @return  the order, as an Integer
      */
-    public String getOrder() {
+    public Integer getOrder() {
         return order;
     }
 
     /**
      * Sets the order of this relationship (used in dynamic views only; e.g. 1.0, 1.1, 2.0, etc).
      *
-     * @param order     the order, as a String
+     * @param order     the order, as an Integer
      */
-    public void setOrder(String order) {
+    public void setOrder(Integer order) {
         this.order = order;
     }
 

--- a/structurizr-core/src/com/structurizr/view/SequenceNumber.java
+++ b/structurizr-core/src/com/structurizr/view/SequenceNumber.java
@@ -7,9 +7,9 @@ class SequenceNumber {
     SequenceNumber() {
     }
 
-    String getNext() {
+    int getNext() {
         counter.increment();
-        return counter.toString();
+        return counter.getSequence();
     }
 
     void startParallelSequence() {

--- a/structurizr-core/src/com/structurizr/view/View.java
+++ b/structurizr-core/src/com/structurizr/view/View.java
@@ -273,7 +273,7 @@ public abstract class View {
         return this.elementViews.stream().filter(ev -> ev.getElement().equals(element)).count() > 0;
     }
 
-    protected RelationshipView addRelationship(Relationship relationship, String description, String order) {
+    protected RelationshipView addRelationship(Relationship relationship, String description, int order) {
         RelationshipView relationshipView = addRelationship(relationship);
         if (relationshipView != null) {
             relationshipView.setDescription(description);

--- a/structurizr-core/test/unit/com/structurizr/view/DynamicViewTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/DynamicViewTests.java
@@ -233,8 +233,8 @@ public class DynamicViewTests extends AbstractWorkspaceTestBase {
         view.add(container1, container2);
         view.add(container1, container3);
 
-        assertSame(container2, view.getRelationships().stream().filter(r -> r.getOrder().equals("1")).findFirst().get().getRelationship().getDestination());
-        assertSame(container3, view.getRelationships().stream().filter(r -> r.getOrder().equals("2")).findFirst().get().getRelationship().getDestination());
+        assertSame(container2, view.getRelationships().stream().filter(r -> r.getOrder().equals(1)).findFirst().get().getRelationship().getDestination());
+        assertSame(container3, view.getRelationships().stream().filter(r -> r.getOrder().equals(2)).findFirst().get().getRelationship().getDestination());
     }
 
     @Test
@@ -270,10 +270,10 @@ public class DynamicViewTests extends AbstractWorkspaceTestBase {
         view.endParallelSequence(true);
         view.add(softwareSystemD, softwareSystemE);
 
-        assertEquals(1, view.getRelationships().stream().filter(r -> r.getOrder().equals("1")).count());
-        assertEquals(2, view.getRelationships().stream().filter(r -> r.getOrder().equals("2")).count());
-        assertEquals(2, view.getRelationships().stream().filter(r -> r.getOrder().equals("3")).count());
-        assertEquals(1, view.getRelationships().stream().filter(r -> r.getOrder().equals("4")).count());
+        assertEquals(1, view.getRelationships().stream().filter(r -> r.getOrder().equals(1)).count());
+        assertEquals(2, view.getRelationships().stream().filter(r -> r.getOrder().equals(2)).count());
+        assertEquals(2, view.getRelationships().stream().filter(r -> r.getOrder().equals(3)).count());
+        assertEquals(1, view.getRelationships().stream().filter(r -> r.getOrder().equals(4)).count());
     }
 
 }

--- a/structurizr-core/test/unit/com/structurizr/view/SequenceNumberTests.java
+++ b/structurizr-core/test/unit/com/structurizr/view/SequenceNumberTests.java
@@ -9,24 +9,24 @@ public class SequenceNumberTests {
     @Test
     public void test_increment() {
         SequenceNumber sequenceNumber = new SequenceNumber();
-        assertEquals("1", sequenceNumber.getNext());
-        assertEquals("2", sequenceNumber.getNext());
+        assertEquals(1, sequenceNumber.getNext());
+        assertEquals(2, sequenceNumber.getNext());
     }
 
     @Test
     public void test_parallelSequences() {
         SequenceNumber sequenceNumber = new SequenceNumber();
-        assertEquals("1", sequenceNumber.getNext());
+        assertEquals(1, sequenceNumber.getNext());
 
         sequenceNumber.startParallelSequence();
-        assertEquals("2", sequenceNumber.getNext());
+        assertEquals(2, sequenceNumber.getNext());
         sequenceNumber.endParallelSequence(false);
 
         sequenceNumber.startParallelSequence();
-        assertEquals("2", sequenceNumber.getNext());
+        assertEquals(2, sequenceNumber.getNext());
         sequenceNumber.endParallelSequence(true);
 
-        assertEquals("3", sequenceNumber.getNext());
+        assertEquals(3, sequenceNumber.getNext());
     }
 
 }


### PR DESCRIPTION
Before we'd get sequence diagrams looking like:

![image](https://user-images.githubusercontent.com/37715/63491872-f0e30a00-c4d5-11e9-8fa7-de955684f4d3.png)

Now they correctly look like:

![image](https://user-images.githubusercontent.com/37715/63492133-6d75e880-c4d6-11e9-854a-373c0d7ef7bd.png)
