### PR TITLE
Allow relationship views to be reversed

### DIFF
--- a/structurizr-core/src/com/structurizr/view/RelationshipView.java
+++ b/structurizr-core/src/com/structurizr/view/RelationshipView.java
@@ -27,6 +27,9 @@ public final class RelationshipView {
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private Integer position;
 
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private boolean reversed;
+
     RelationshipView() {
     }
 
@@ -100,6 +103,23 @@ public final class RelationshipView {
      */
     public void setOrder(String order) {
         this.order = order;
+    }
+
+    /**
+     * @return  whether the relationship should be viewed in reverse
+     */
+    public boolean isReversed() {
+        return reversed;
+    }
+
+    /**
+     * Toggles whether the relationship should be viewed in reverse.
+     *
+     * @return  the relationship view
+     */
+    public RelationshipView reverse() {
+        reversed = !reversed;
+        return this;
     }
 
     /**

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
@@ -378,9 +378,11 @@ public class PlantUMLWriter {
                     .forEach(relationship -> {
                         try {
                             writer.write(
-                                    format("%s -[%s]> %s : %s. %s",
+                                    format("%s %s-[%s]%s %s : %s. %s",
                                             idOf(relationship.getRelationship().getSource()),
+                                            relationship.isReversed() ? "<" : "",
                                             view.getViewSet().getConfiguration().getStyles().findRelationshipStyle(relationship.getRelationship()).getColor(),
+                                            relationship.isReversed() ? "-" : ">",
                                             idOf(relationship.getRelationship().getDestination()),
                                             relationship.getOrder(),
                                             hasValue(relationship.getDescription()) ? relationship.getDescription() : hasValue(relationship.getRelationship().getDescription()) ? relationship.getRelationship().getDescription() : ""

--- a/structurizr-plantuml/test/unit/com/structurizr/io/plantuml/PlantUMLWriterTests.java
+++ b/structurizr-plantuml/test/unit/com/structurizr/io/plantuml/PlantUMLWriterTests.java
@@ -228,6 +228,7 @@ public class PlantUMLWriterTests {
         dynamicView.add(user, "Requests /something", controller);
         dynamicView.add(controller, repository);
         dynamicView.add(repository, "select * from something", database);
+        dynamicView.add(repository, "Results from something", database).reverse();
 
         DeploymentView deploymentView = workspace.getViews().createDeploymentView(softwareSystem, "deployment", "");
         deploymentView.addAllDeploymentNodes();
@@ -648,6 +649,7 @@ public class PlantUMLWriterTests {
             "1 -[#707070]> 12 : 1. Requests /something" + System.lineSeparator() +
             "12 -[#707070]> 14 : 2. Uses" + System.lineSeparator() +
             "14 -[#707070]> 8 : 3. select * from something" + System.lineSeparator() +
+            "14 <-[#707070]- 8 : 4. Results from something" + System.lineSeparator() +
             "@enduml" + System.lineSeparator();
 
     private static final String DYNAMIC_VIEW_SEQUENCE = "@startuml(id=dynamic)" + System.lineSeparator() +
@@ -670,6 +672,7 @@ public class PlantUMLWriterTests {
             "1 -[#707070]> 12 : 1. Requests /something" + System.lineSeparator() +
             "12 -[#707070]> 14 : 2. Uses" + System.lineSeparator() +
             "14 -[#707070]> 8 : 3. select * from something" + System.lineSeparator() +
+            "14 <-[#707070]- 8 : 4. Results from something" + System.lineSeparator() +
             "@enduml" + System.lineSeparator();
 
 


### PR DESCRIPTION
Useful for representing responses in sequence diagrams.

Allows sequence diagrams like:

![image](https://user-images.githubusercontent.com/37715/63492422-16bcde80-c4d7-11e9-88e2-1dd6059ee727.png)

---

Opening this PR for some discussion. Is this along the right way to implement this feature? Is there a more appropriate way of generating these diagrams? Should this reverse relationship view be implemented for other types of diagrams?