### PR TITLE
GH-125 Change semantics of hasTag to consider requiredTags as well

### DIFF
--- a/structurizr-core/src/com/structurizr/model/ContainerInstance.java
+++ b/structurizr-core/src/com/structurizr/model/ContainerInstance.java
@@ -78,8 +78,9 @@ public final class ContainerInstance extends DeploymentElement {
     }
 
     @Override
-    public void removeTag(String tag) {
+    public boolean removeTag(String tag) {
         // do nothing ... tags cannot be removed from container instances (they should reflect the container they are based upon)
+        return false;
     }
 
     @Override

--- a/structurizr-core/src/com/structurizr/model/ModelItem.java
+++ b/structurizr-core/src/com/structurizr/model/ModelItem.java
@@ -83,14 +83,27 @@ abstract class ModelItem {
         }
     }
 
-    public void removeTag(String tag) {
+    /**
+     *
+     * @param tag
+     * @return True if the tag was removed. Will return false if a non-existent tag is passed, or if an attempt is
+     * made to remove requiredTags, which cannot be removed.
+     */
+    public boolean removeTag(String tag) {
         if (tag != null) {
-            this.tags.remove(tag);
+            return this.tags.remove(tag);
         }
+        return false;
     }
 
+    /**
+     *
+     * @param tag
+     * @return True if tag is present as a tag on this item, or if it is one of the
+     * required tags defined by the model in getRequiredTags()
+     */
     public boolean hasTag(String tag) {
-        return this.tags.contains(tag);
+        return getTagsAsSet().contains(tag);
     }
 
     /**

--- a/structurizr-core/test/unit/com/structurizr/model/ModelItemTests.java
+++ b/structurizr-core/test/unit/com/structurizr/model/ModelItemTests.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class ModelItemTests extends AbstractWorkspaceTestBase {
@@ -23,6 +24,13 @@ public class ModelItemTests extends AbstractWorkspaceTestBase {
     public void test_getTags_WhenThereAreNoTags() {
         Element element = model.addSoftwareSystem("Name", "Description");
         assertEquals("Element,Software System", element.getTags());
+    }
+
+    @Test
+    public void test_hasTag_ChecksRequiredTags() {
+        SoftwareSystem system = model.addSoftwareSystem("Name", "Description");
+        assertTrue("hasTag returns true for Software System", system.hasTag("Software System"));
+        assertTrue("hasTag returns true for Element", system.hasTag("Element"));
     }
 
     @Test
@@ -63,6 +71,16 @@ public class ModelItemTests extends AbstractWorkspaceTestBase {
         assertEquals("Element,Software System,tag1,tag2", element.getTags());
     }
 
+    @Test
+    public void test_removeTags() {
+        Element element = model.addSoftwareSystem("Name", "Description");
+        element.addTags("tag1", "tag2");
+        assertTrue("Remove an existing tag returns true", element.removeTag("tag1"));
+        assertFalse("Tag has been removed", element.hasTag("tag1"));
+
+        assertFalse("Remove a non-existing tag returns false", element.removeTag("no-such-tag"));
+        assertFalse("Remove a required tag returns false", element.removeTag("Element"));
+    }
     @Test
     public void test_getProperties_ReturnsAnEmptyList_WhenNoPropertiesHaveBeenAdded() {
         Element element = model.addSoftwareSystem("Name", "Description");


### PR DESCRIPTION
Fixes GH-125
Update removeTag method to return a boolean, similar to HashSet semantics
Update tests to demonstrate the new behavior