### PR TITLE
Fix Styles find*Style methods

### DIFF
--- a/structurizr-core/src/com/structurizr/view/Styles.java
+++ b/structurizr-core/src/com/structurizr/view/Styles.java
@@ -138,8 +138,36 @@ public final class Styles {
             for (String tag : relationship.getTagsAsSet()) {
                 RelationshipStyle relationshipStyle = findRelationshipStyle(tag);
                 if (relationshipStyle != null) {
-                    if (relationshipStyle.getColor() != null && relationshipStyle.getColor().trim().length() > 0) {
+                    if (relationshipStyle.getThickness() != null) {
+                        style.setThickness(relationshipStyle.getThickness());
+                    }
+
+                    if (!StringUtils.isNullOrEmpty(relationshipStyle.getColor())) {
                         style.setColor(relationshipStyle.getColor());
+                    }
+
+                    if (relationshipStyle.getDashed() != null) {
+                        style.setDashed(relationshipStyle.getDashed());
+                    }
+
+                    if (relationshipStyle.getRouting() != null) {
+                        style.setRouting(relationshipStyle.getRouting());
+                    }
+
+                    if (relationshipStyle.getFontSize() != null) {
+                        style.setFontSize(relationshipStyle.getFontSize());
+                    }
+
+                    if (relationshipStyle.getWidth() != null) {
+                        style.setWidth(relationshipStyle.getWidth());
+                    }
+
+                    if (relationshipStyle.getPosition() != null) {
+                        style.setPosition(relationshipStyle.getPosition());
+                    }
+
+                    if (relationshipStyle.getOpacity() != null) {
+                        style.setOpacity(relationshipStyle.getOpacity());
                     }
                 }
             }

--- a/structurizr-core/src/com/structurizr/view/Styles.java
+++ b/structurizr-core/src/com/structurizr/view/Styles.java
@@ -109,6 +109,14 @@ public final class Styles {
             for (String tag : element.getTagsAsSet()) {
                 ElementStyle elementStyle = findElementStyle(tag);
                 if (elementStyle != null) {
+                    if (elementStyle.getWidth() != null) {
+                        style.setWidth(elementStyle.getWidth());
+                    }
+
+                    if (elementStyle.getHeight() != null) {
+                        style.setHeight(elementStyle.getHeight());
+                    }
+
                     if (!StringUtils.isNullOrEmpty(elementStyle.getBackground())) {
                         style.setBackground(elementStyle.getBackground());
                     }
@@ -121,8 +129,20 @@ public final class Styles {
                         style.setStroke(elementStyle.getStroke());
                     }
 
+                    if (elementStyle.getFontSize() != null) {
+                        style.setFontSize(elementStyle.getFontSize());
+                    }
+
                     if (elementStyle.getShape() != null) {
                         style.setShape(elementStyle.getShape());
+                    }
+
+                    if (elementStyle.getBorder() != null) {
+                        style.setBorder(elementStyle.getBorder());
+                    }
+
+                    if (elementStyle.getOpacity() != null) {
+                        style.setOpacity(elementStyle.getOpacity());
                     }
                 }
             }


### PR DESCRIPTION
# Description
I stumbled on this by accident while working on an improved DotWriter.
The 2 find*Style methods in the Styles class where 

1. inconsistent with another
2. would ignore certain style characteristics that the documentation mentioned as valid
  * [Relationship Charactersitics](https://github.com/structurizr/java/blob/90d63149039bdb6dc025fcf9d67410d852f9a59f/docs/styling-relationships.md)
  * [Element Charactersitics](https://github.com/structurizr/java/blob/90d63149039bdb6dc025fcf9d67410d852f9a59f/docs/styling-elements.md)

# PR Content
I simply unified the two find*Style methods and added all missing characteristics to the returned style, should the characteristics be set for a given tag.

---

**Personal Note** Hope this PR is formatted to an acceptable format and I didn't miss something obvious.
The improved DotWriter will get a PR in the extension repository when I'm satisfied with my code 🤷‍♂ 