### PR TITLE
Support fixed version with a JDK to handle that

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,14 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [11, 11.0.3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
'adopt' no longer exists, here's a pull request for 'zulu', with support for testing on whatever the latest version of 11 is as well as a fixed version, 11.0.3, so you can easily identify where the problem is if a build fails. :-)