### PR TITLE
fix: re-enable system properties for theme http client

### DIFF
--- a/structurizr-client/src/main/java/com/structurizr/view/ThemeUtils.java
+++ b/structurizr-client/src/main/java/com/structurizr/view/ThemeUtils.java
@@ -95,6 +95,7 @@ public final class ThemeUtils {
             cm.setConnectionConfig(connectionConfig);
 
             CloseableHttpClient httpClient = HttpClientBuilder.create()
+                    .useSystemProperties()
                     .setConnectionManager(cm)
                     .build();
 


### PR DESCRIPTION
In order to set https.proxyHost and co externally (see https://hc.apache.org/httpcomponents-client-5.1.x/current/httpclient5/apidocs/ and https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) the method useSystemProperties() must be called on the HttpClientBuilder.

This re-enables the system properties removed (inadvertently?) in this commit: https://github.com/structurizr/java/commit/e2a6fecb1a51f597d3185ffa85c4afbe8c8211dc

We need to be able to set a proxy for all http connections, in this case the theme download.

Thanks!