### PR TITLE
Fix the locale used by SimpleDateFormat objects to Locale.US.

### DIFF
--- a/structurizr-import/src/test/java/com/structurizr/importer/documentation/AdrToolsDecisionImporterTests.java
+++ b/structurizr-import/src/test/java/com/structurizr/importer/documentation/AdrToolsDecisionImporterTests.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -81,7 +81,7 @@ public class AdrToolsDecisionImporterTests {
         Decision decision1 = documentation.getDecisions().stream().filter(d -> d.getId().equals("1")).findFirst().get();
         assertEquals("1", decision1.getId());
         assertEquals("Record architecture decisions", decision1.getTitle());
-        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy", Locale.US);
         assertEquals("12-Feb-2016", sdf.format(decision1.getDate()));
         assertEquals("Accepted", decision1.getStatus());
         Assertions.assertEquals(Format.Markdown, decision1.getFormat());

--- a/structurizr-import/src/test/java/com/structurizr/importer/documentation/Log4brainsDecisionImporterTests.java
+++ b/structurizr-import/src/test/java/com/structurizr/importer/documentation/Log4brainsDecisionImporterTests.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -75,7 +75,7 @@ public class Log4brainsDecisionImporterTests {
     @Test
     public void test_importDecisions() {
         decisionImporter.importDocumentation(workspace, DECISIONS_FOLDER);
-        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy", Locale.US);
 
         assertEquals(4, documentation.getDecisions().size());
 

--- a/structurizr-import/src/test/java/com/structurizr/importer/documentation/MadrDecisionImporterTests.java
+++ b/structurizr-import/src/test/java/com/structurizr/importer/documentation/MadrDecisionImporterTests.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -75,7 +75,7 @@ public class MadrDecisionImporterTests {
     @Test
     public void test_importDecisions() {
         decisionImporter.importDocumentation(workspace, DECISIONS_FOLDER);
-        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy", Locale.US);
 
         assertEquals(19, documentation.getDecisions().size());
 


### PR DESCRIPTION
Some tests were failing because of the Locale used by the SimpleDateFormat was automatically resolved according to the location where the tests are run.

I simply fixed it to the Locale.US value