### PR TITLE
Add options to the StructurizrDslParser 

### DIFF
--- a/structurizr-dsl/build.gradle
+++ b/structurizr-dsl/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 description = 'Structurizr DSL'

--- a/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParser.java
+++ b/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParser.java
@@ -43,6 +43,7 @@ public final class StructurizrDslParser extends StructurizrDslTokens {
     private final Set<String> parsedTokens = new HashSet<>();
     private final IdentifiersRegister identifiersRegister;
     private final Map<String, Constant> constants;
+    private final StructurizrDslParserOptions parserOptions;
 
     private final List<String> dslSourceLines = new ArrayList<>();
     private Workspace workspace;
@@ -54,9 +55,14 @@ public final class StructurizrDslParser extends StructurizrDslTokens {
      * Creates a new instance of the parser.
      */
     public StructurizrDslParser() {
+        this(new StructurizrDslParserOptions(false));
+    }
+
+    public StructurizrDslParser(StructurizrDslParserOptions options) {
         contextStack = new Stack<>();
         identifiersRegister = new IdentifiersRegister();
         constants = new HashMap<>();
+        parserOptions = options;
     }
 
     /**
@@ -874,7 +880,11 @@ public final class StructurizrDslParser extends StructurizrDslTokens {
                     } else if (CONSTANT_TOKEN.equalsIgnoreCase(firstToken)) {
                         Constant constant = new ConstantParser().parse(getContext(), tokens);
                         if (constants.containsKey(constant.getName())) {
-                            log.warn("A constant named " + constant.getName() + " already exists");
+                            String message = "A constant named " + constant.getName() + " already exists";
+                            if(parserOptions.uniqueConstantsDeclaration()) {
+                                throw new StructurizrDslParserException(message);
+                            }
+                            log.warn(message);
                         }
                         constants.put(constant.getName(), constant);
 

--- a/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParserOptions.java
+++ b/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParserOptions.java
@@ -1,0 +1,9 @@
+package com.structurizr.dsl;
+
+/**
+ * @param uniqueConstantsDeclaration If set to true, then constants declared with the !constant keyword cannot be overridden.
+ */
+public record StructurizrDslParserOptions(
+        boolean uniqueConstantsDeclaration
+) {
+}

--- a/structurizr-dsl/src/test/java/com/structurizr/dsl/UniqueConstantsConfigurationTests.java
+++ b/structurizr-dsl/src/test/java/com/structurizr/dsl/UniqueConstantsConfigurationTests.java
@@ -1,0 +1,26 @@
+package com.structurizr.dsl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class UniqueConstantsConfigurationTests {
+
+    @Test
+    void shouldFailOnConstantDuplication() {
+        String dsl = """
+                    workspace {
+                        !constant NAME toto
+                        !constant NAME titi
+                    }
+                """;
+
+        StructurizrDslParser parser = new StructurizrDslParser(
+                new StructurizrDslParserOptions(true)
+        );
+
+        assertThatCode(() -> parser.parse(dsl))
+                .isInstanceOf(StructurizrDslParserException.class)
+                .hasMessageStartingWith("A constant named NAME already exists");
+    }
+}


### PR DESCRIPTION
Related to #253 

After digging a bit more into the parser, it seems that adding a property to the DSL to be able to force constant declaration uniqueness is not trivial. Indeed, since the parsing is purely linear and checks rules "just in time", I did not see a simple way to prevent overrides before actually parsing the property that would forbid them.

Hence, I made this PR as a suggestion to at least allow people who use the StructurizrDslParser API directly in code to parametrize this behavior via options passed to the parser on invocation.

The only option is to force unique constant declaration, in order to prevent constants override inside a workspace.
Even if there is only one option, I feel like creating a dedicated object that contains everything will be more extensible in the probable case where one would suggest more parametrization of the parser behavior.
