### PR TITLE
Ability to invert relationship arrow in plantuml

### DIFF
--- a/structurizr-core/src/main/java/com/structurizr/model/Model.java
+++ b/structurizr-core/src/main/java/com/structurizr/model/Model.java
@@ -914,9 +914,9 @@ public final class Model implements PropertyHolder {
 
             for (Relationship relationship : element.getRelationships()) {
                 if (relationship.getDestination().equals(sse)) {
-                    Relationship newRelationship = addRelationship(elementInstance, ssei, relationship.getDescription(), relationship.getTechnology(), relationship.getInteractionStyle());
+                    Relationship newRelationship = addRelationship(elementInstance, ssei, relationship.getDescription(), relationship.getTechnology(), relationship.getInteractionStyle(), relationship.getTagsAsSet().stream().toArray(String[] ::new));
                     if (newRelationship != null) {
-                        newRelationship.setTags(null);
+                        // newRelationship.setTags(null);
                         newRelationship.setLinkedRelationshipId(relationship.getId());
                     }
                 }
@@ -924,9 +924,9 @@ public final class Model implements PropertyHolder {
 
             for (Relationship relationship : sse.getRelationships()) {
                 if (relationship.getDestination().equals(element)) {
-                    Relationship newRelationship = addRelationship(ssei, elementInstance, relationship.getDescription(), relationship.getTechnology(), relationship.getInteractionStyle());
+                    Relationship newRelationship = addRelationship(ssei, elementInstance, relationship.getDescription(), relationship.getTechnology(), relationship.getInteractionStyle(), relationship.getTagsAsSet().stream().toArray(String[] ::new));
                     if (newRelationship != null) {
-                        newRelationship.setTags(null);
+                        // newRelationship.setTags(null);
                         newRelationship.setLinkedRelationshipId(relationship.getId());
                     }
                 }

--- a/structurizr-core/src/test/java/com/structurizr/model/ModelTests.java
+++ b/structurizr-core/src/test/java/com/structurizr/model/ModelTests.java
@@ -421,7 +421,7 @@ public class ModelTests extends AbstractWorkspaceTestBase {
         assertEquals("Uses 1", relationship.getDescription());
         assertEquals("Technology 1", relationship.getTechnology());
         assertEquals(InteractionStyle.Synchronous, relationship.getInteractionStyle());
-        assertEquals("", relationship.getTags());
+        assertEquals("Relationship,Synchronous", relationship.getTags());
 
         assertEquals(1, containerInstance2.getRelationships().size());
         relationship = containerInstance2.getRelationships().iterator().next();
@@ -430,7 +430,7 @@ public class ModelTests extends AbstractWorkspaceTestBase {
         assertEquals("Uses 2", relationship.getDescription());
         assertEquals("Technology 2", relationship.getTechnology());
         assertEquals(InteractionStyle.Asynchronous, relationship.getInteractionStyle());
-        assertEquals("", relationship.getTags());
+        assertEquals("Relationship,Asynchronous", relationship.getTags());
 
         assertEquals(1, containerInstance3.getRelationships().size());
         relationship = containerInstance3.getRelationships().iterator().next();
@@ -439,7 +439,7 @@ public class ModelTests extends AbstractWorkspaceTestBase {
         assertEquals("Uses", relationship.getDescription());
         assertNull(relationship.getTechnology());
         assertNull(relationship.getInteractionStyle());
-        assertEquals("", relationship.getTags());
+        assertEquals("Relationship", relationship.getTags());
     }
 
     @Test

--- a/structurizr-export/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
+++ b/structurizr-export/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
@@ -437,7 +437,14 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
                 relationshipStyle += ",thickness=" + style.getThickness();
             }
 
-            if (relationshipView.isResponse() != null && relationshipView.isResponse()) {
+            String sourceId = idOf(relationship.getSource());
+            String destId = idOf(relationship.getDestination());
+
+            Boolean reversed = relationship.getTagsAsSet().contains("reversed-flow") ||
+                    "true".equalsIgnoreCase(getViewOrViewSetProperty(view,
+                            "plantuml.reversedFlowRelation." + sourceId + "-" + destId, "false"));
+
+            if (reversed || (relationshipView.isResponse() != null && relationshipView.isResponse())) {
                 arrowStart = solid ? "<-" : "<.";
                 arrowEnd = solid ? "-" : ".";
             } else {
@@ -449,13 +456,19 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
                 relationshipStyle = "hidden";
             }
 
+            if (reversed) {
+                String tmp = sourceId;
+                sourceId = destId;
+                destId = tmp;
+            }
+
             // 1 .[#rrggbb,thickness=n].> 2 : "...\n<size:8>...</size>
             writer.writeLine(format("%s %s[%s]%s %s : \"<color:%s>%s%s\"",
-                    idOf(relationship.getSource()),
+                    sourceId,
                     arrowStart,
                     relationshipStyle,
                     arrowEnd,
-                    idOf(relationship.getDestination()),
+                    destId,
                     style.getColor(),
                     description,
                     (StringUtils.isNullOrEmpty(technology) ? "" : "\\n<color:" + style.getColor() + "><size:8>[" + technology + "]</size>")

--- a/structurizr-export/src/test/java/com/structurizr/export/plantuml/StructurizrPlantUMLDiagramExporterTests.java
+++ b/structurizr-export/src/test/java/com/structurizr/export/plantuml/StructurizrPlantUMLDiagramExporterTests.java
@@ -294,6 +294,32 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
     }
 
     @Test
+    public void test_renderComponentDiagramWithAReversedFlowArrow() throws Exception {
+        Workspace workspace = new Workspace("Name", "Description");
+
+        SoftwareSystem softwareSystem1 = workspace.getModel().addSoftwareSystem("Software System 1");
+        Container container1 = softwareSystem1.addContainer("Container 1");
+        Component component1 = container1.addComponent("Component 1");
+        Component component2 = container1.addComponent("Component 2");
+
+        SoftwareSystem softwareSystem2 = workspace.getModel().addSoftwareSystem("Software System 2");
+        Container container2 = softwareSystem2.addContainer("Container 2");
+        Component component3 = container2.addComponent("Component 3");
+
+        component1.uses(component2, "Uses").addTags("reversed-flow");
+        component2.uses(component3, "Uses");
+
+        ComponentView componentView = workspace.getViews().createComponentView(container1, "Components", "");
+        componentView.add(component1);
+        componentView.add(component2);
+        componentView.add(component3);
+
+        Diagram diagram = new StructurizrPlantUMLExporter().export(componentView);
+        String expected = readFile(new File("./src/test/java/com/structurizr/export/plantuml/structurizr/component-view-with-reversed-arrows-1.puml"));
+        assertEquals(expected, diagram.getDefinition());
+    }
+
+    @Test
     public void test_renderDynamicDiagramWithExternalContainers() {
         Workspace workspace = new Workspace("Name", "Description");
         SoftwareSystem softwareSystem1 = workspace.getModel().addSoftwareSystem("Software System 1");
@@ -615,34 +641,34 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
                 @startuml
                 set separator none
                 title System Landscape
-                                
+
                 top to bottom direction
-                                
+
                 skinparam {
                   arrowFontSize 10
                   defaultTextAlignment center
                   wrapWidth 200
                   maxMessageSize 100
                 }
-                                
+
                 hide stereotype
-                                
+
                 skinparam rectangle<<SoftwareSystem>> {
                   BackgroundColor #dddddd
                   FontColor #000000
                   BorderColor #9a9a9a
                   shadowing false
                 }
-                                
+
                 rectangle "Group" <<group1>> as group1 {
                   skinparam RectangleBorderColor<<group1>> #cccccc
                   skinparam RectangleFontColor<<group1>> #cccccc
                   skinparam RectangleBorderStyle<<group1>> dashed
-                                
+
                   rectangle "==Software System\\n<size:10>[Software System]</size>" <<SoftwareSystem>> as SoftwareSystem
                 }
-                                
-                                
+
+
                 @enduml""";
 
         diagram = exporter.export(view);
@@ -794,18 +820,18 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
                 @startuml
                 set separator none
                 title Software System - Containers
-                                
+
                 top to bottom direction
-                                
+
                 skinparam {
                   arrowFontSize 10
                   defaultTextAlignment center
                   wrapWidth 200
                   maxMessageSize 100
                 }
-                                
+
                 hide stereotype
-                                
+
                 skinparam rectangle<<SoftwareSystem.Container1>> {
                   BackgroundColor #dddddd
                   FontColor #000000
@@ -823,26 +849,26 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
                   FontColor #9a9a9a
                   shadowing false
                 }
-                                
+
                 rectangle "Software System\\n<size:10>[Software System]</size>" <<SoftwareSystem>> {
                   rectangle "Group 1" <<group1>> as group1 {
                     skinparam RectangleBorderColor<<group1>> #cccccc
                     skinparam RectangleFontColor<<group1>> #cccccc
                     skinparam RectangleBorderStyle<<group1>> dashed
-                                
+
                     rectangle "==Container 1\\n<size:10>[Container]</size>" <<SoftwareSystem.Container1>> as SoftwareSystem.Container1
                   }
-                                
+
                   rectangle "Group 2" <<group2>> as group2 {
                     skinparam RectangleBorderColor<<group2>> #cccccc
                     skinparam RectangleFontColor<<group2>> #cccccc
                     skinparam RectangleBorderStyle<<group2>> dashed
-                                
+
                     rectangle "==Container 2\\n<size:10>[Container]</size>" <<SoftwareSystem.Container2>> as SoftwareSystem.Container2
                   }
-                                
+
                 }
-                                
+
                 @enduml""";
 
         StructurizrPlantUMLExporter exporter = new StructurizrPlantUMLExporter();
@@ -880,18 +906,18 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
                 @startuml
                 set separator none
                 title Deployment - Default
-                                
+
                 top to bottom direction
-                                
+
                 skinparam {
                   arrowFontSize 10
                   defaultTextAlignment center
                   wrapWidth 200
                   maxMessageSize 100
                 }
-                                
+
                 hide stereotype
-                                
+
                 skinparam rectangle<<Default.Server1.InfrastructureNode1>> {
                   BackgroundColor #dddddd
                   FontColor #000000
@@ -916,27 +942,27 @@ public class StructurizrPlantUMLDiagramExporterTests extends AbstractExporterTes
                   BorderColor #9a9a9a
                   shadowing false
                 }
-                                
+
                 rectangle "Group 1" <<group1>> as group1 {
                   skinparam RectangleBorderColor<<group1>> #cccccc
                   skinparam RectangleFontColor<<group1>> #cccccc
                   skinparam RectangleBorderStyle<<group1>> dashed
-                                
+
                   rectangle "Server 1\\n<size:10>[Deployment Node]</size>" <<Default.Server1>> as Default.Server1 {
                     rectangle "Group 2" <<group2>> as group2 {
                       skinparam RectangleBorderColor<<group2>> #cccccc
                       skinparam RectangleFontColor<<group2>> #cccccc
                       skinparam RectangleBorderStyle<<group2>> dashed
-                                
+
                       rectangle "==Infrastructure Node 2\\n<size:10>[Infrastructure Node]</size>" <<Default.Server1.InfrastructureNode2>> as Default.Server1.InfrastructureNode2
                       rectangle "==Software System\\n<size:10>[Software System]</size>" <<Default.Server1.SoftwareSystem_1>> as Default.Server1.SoftwareSystem_1
                     }
-                                
+
                     rectangle "==Infrastructure Node 1\\n<size:10>[Infrastructure Node]</size>" <<Default.Server1.InfrastructureNode1>> as Default.Server1.InfrastructureNode1
                   }
-                                
+
                 }
-                                
+
                 @enduml""";
 
         StructurizrPlantUMLExporter exporter = new StructurizrPlantUMLExporter();
@@ -1048,34 +1074,34 @@ rectangle "Node\\n<size:10>[Deployment Node]</size>" <<Default.Node>> as Default
                 @startuml
                 set separator none
                 title System Landscape
-                                
+
                 top to bottom direction
-                                
+
                 skinparam {
                   arrowFontSize 10
                   defaultTextAlignment center
                   wrapWidth 200
                   maxMessageSize 100
                 }
-                                
+
                 hide stereotype
-                                
+
                 skinparam rectangle<<Name>> {
                   BackgroundColor #dddddd
                   FontColor #000000
                   BorderColor #9a9a9a
                   shadowing false
                 }
-                                
+
                 rectangle "Name" <<group1>> as group1 {
                   skinparam RectangleBorderColor<<group1>> #cccccc
                   skinparam RectangleFontColor<<group1>> #cccccc
                   skinparam RectangleBorderStyle<<group1>> dashed
-                                
+
                   rectangle "==Name\\n<size:10>[Software System]</size>" <<Name>> as Name
                 }
-                                
-                                
+
+
                 @enduml""", diagram.getDefinition());
     }
 

--- a/structurizr-export/src/test/java/com/structurizr/export/plantuml/structurizr/component-view-with-reversed-arrows-1.puml
+++ b/structurizr-export/src/test/java/com/structurizr/export/plantuml/structurizr/component-view-with-reversed-arrows-1.puml
@@ -1,0 +1,56 @@
+@startuml
+set separator none
+title Software System 1 - Container 1 - Components
+
+top to bottom direction
+
+skinparam {
+  arrowFontSize 10
+  defaultTextAlignment center
+  wrapWidth 200
+  maxMessageSize 100
+}
+
+hide stereotype
+
+skinparam rectangle<<SoftwareSystem1.Container1.Component1>> {
+  BackgroundColor #dddddd
+  FontColor #000000
+  BorderColor #9a9a9a
+  shadowing false
+}
+skinparam rectangle<<SoftwareSystem1.Container1.Component2>> {
+  BackgroundColor #dddddd
+  FontColor #000000
+  BorderColor #9a9a9a
+  shadowing false
+}
+skinparam rectangle<<SoftwareSystem2.Container2.Component3>> {
+  BackgroundColor #dddddd
+  FontColor #000000
+  BorderColor #9a9a9a
+  shadowing false
+}
+skinparam rectangle<<SoftwareSystem1.Container1>> {
+  BorderColor #9a9a9a
+  FontColor #9a9a9a
+  shadowing false
+}
+skinparam rectangle<<SoftwareSystem2.Container2>> {
+  BorderColor #9a9a9a
+  FontColor #9a9a9a
+  shadowing false
+}
+
+rectangle "Container 1\n<size:10>[Container]</size>" <<SoftwareSystem1.Container1>> {
+  rectangle "==Component 1\n<size:10>[Component]</size>" <<SoftwareSystem1.Container1.Component1>> as SoftwareSystem1.Container1.Component1
+  rectangle "==Component 2\n<size:10>[Component]</size>" <<SoftwareSystem1.Container1.Component2>> as SoftwareSystem1.Container1.Component2
+}
+
+rectangle "Container 2\n<size:10>[Container]</size>" <<SoftwareSystem2.Container2>> {
+  rectangle "==Component 3\n<size:10>[Component]</size>" <<SoftwareSystem2.Container2.Component3>> as SoftwareSystem2.Container2.Component3
+}
+
+SoftwareSystem1.Container1.Component2 <.[#707070,thickness=2]. SoftwareSystem1.Container1.Component1 : "<color:#707070>Uses"
+SoftwareSystem1.Container1.Component2 .[#707070,thickness=2].> SoftwareSystem2.Container2.Component3 : "<color:#707070>Uses"
+@enduml


### PR DESCRIPTION
This feature is useful to control the plantuml layout, e.g. for diagrams where the arrows indicate control flow, but the layout - data flow