### PR TITLE
Removes redundant spaces in single tokens with multiline separators

### DIFF
--- a/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParser.java
+++ b/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslParser.java
@@ -1212,8 +1212,13 @@ public final class StructurizrDslParser extends StructurizrDslTokens {
 
         for (String line : lines) {
             if (!COMMENT_PATTERN.matcher(line).matches() && line.endsWith(MULTI_LINE_SEPARATOR)) {
-                buf.append(line, 0, line.length()-1);
-                lineComplete = false;
+                if (lineComplete) {
+                    buf.append(line, 0, line.length()-1);
+                    lineComplete = false;
+                } else {
+                    String strippedLine = line.stripLeading();
+                    buf.append(strippedLine, 0, strippedLine.length() - 1);
+                }
             } else {
                 if (lineComplete) {
                     buf.append(line);

--- a/structurizr-dsl/src/test/java/com/structurizr/dsl/DslTests.java
+++ b/structurizr-dsl/src/test/java/com/structurizr/dsl/DslTests.java
@@ -1142,6 +1142,14 @@ class DslTests extends AbstractTests {
     }
 
     @Test
+    void test_MultiLineInTheMiddleOfTheStringSupport() throws Exception {
+        StructurizrDslParser parser = new StructurizrDslParser();
+        parser.parse(new File("src/test/resources/dsl/multi-line-break-string.dsl"));
+
+        assertNotNull(parser.getWorkspace().getModel().getSoftwareSystemWithName("Software System"));
+    }
+
+    @Test
     void test_MultiLineWithError() {
         File dslFile = new File("src/test/resources/dsl/multi-line-with-error.dsl");
 

--- a/structurizr-dsl/src/test/resources/dsl/multi-line-break-string.dsl
+++ b/structurizr-dsl/src/test/resources/dsl/multi-line-break-string.dsl
@@ -1,0 +1,20 @@
+work\
+    sp\
+    ace {
+
+    mo\
+        d\
+        el {
+            soft\
+                wareSys\
+                tem = \
+                    soft\
+                        wareSys\
+                        tem \
+            "Sof\
+            tware \
+            Sys\
+            tem"
+    }
+
+}


### PR DESCRIPTION
Now cases when a single keyword is split by multiple multiline separators are supported.
```structurizr
work\
 spa\
 ce {
}
```

Also fixes redundant spaces inside quoted strings. The following code was parsed as `"Soft  ware   System"` before.
```structurizr
"Soft\
   ware \
   Sys\
   tem"
```

BREAKING CHANGE!
The following code produced valid workspace before, because whitespaces in the second line were preserved. Now the first three lines will produce a single token `workspace{`.
```structurizr
workspace\
 \
  {
}
```