### PR TITLE
Optimizing SequentialIntegerIdGeneratorStrategy

### DIFF
--- a/structurizr-core/src/main/java/com/structurizr/model/SequentialIntegerIdGeneratorStrategy.java
+++ b/structurizr-core/src/main/java/com/structurizr/model/SequentialIntegerIdGeneratorStrategy.java
@@ -1,29 +1,31 @@
 package com.structurizr.model;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * An ID generator that simply uses a sequential number when generating IDs for model elements and relationships.
  * This is the default ID generator; any non-numeric IDs are ignored.
  */
 public class SequentialIntegerIdGeneratorStrategy implements IdGenerator {
 
-    private int ID = 0;
+    private final AtomicInteger id = new AtomicInteger();
 
     @Override
-    public synchronized String generateId(Element element) {
-        return "" + ++ID;
+    public String generateId(Element element) {
+        return Integer.toString(id.incrementAndGet());
     }
 
     @Override
-    public synchronized String generateId(Relationship relationship) {
-        return "" + ++ID;
+    public String generateId(Relationship relationship) {
+        return Integer.toString(id.incrementAndGet());
     }
 
     @Override
     public void found(String id) {
         try {
             int idAsInt = Integer.parseInt(id);
-            if (idAsInt > ID) {
-                ID = idAsInt;
+            if (idAsInt > this.id.get()) {
+                this.id.set(idAsInt);
             }
         } catch (NumberFormatException e) {
             // ignore non-numeric IDs


### PR DESCRIPTION
Doesn't really fix a bug (therefore no ticket, the previous code worked correctly as well), just syntactic sugar and slight performance increasements by not synchronizing the whole object, rather use `AtomicInteger` for concurrent integer increase and `Integer.toString()`  for string conversion.


