### PR TITLE
Implement support for `relationship!=` expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bin
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# MacOS files
+.DS_Store
+
 structurizr-dsl/src/test/resources/dsl/spring-petclinic/.structurizr
 structurizr-dsl/src/test/resources/dsl/spring-petclinic/workspace.json
 

--- a/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslExpressions.java
+++ b/structurizr-dsl/src/main/java/com/structurizr/dsl/StructurizrDslExpressions.java
@@ -18,9 +18,12 @@ class StructurizrDslExpressions {
     static final String RELATIONSHIP_PROPERTY_EQUALS_EXPRESSION = "relationship\\.properties\\[.*]==.*";
 
     static final String RELATIONSHIP_SOURCE_EQUALS_EXPRESSION = "relationship.source==";
+    static final String RELATIONSHIP_SOURCE_NOT_EQUALS_EXPRESSION = "relationship.source!=";
     static final String RELATIONSHIP_DESTINATION_EQUALS_EXPRESSION = "relationship.destination==";
+    static final String RELATIONSHIP_DESTINATION_NOT_EQUALS_EXPRESSION = "relationship.destination!=";
 
     static final String RELATIONSHIP_EQUALS_EXPRESSION = "relationship==";
+    static final String RELATIONSHIP_NOT_EQUALS_EXPRESSION = "relationship!=";
 
     static final String RELATIONSHIP = "->";
 

--- a/structurizr-dsl/src/test/java/com/structurizr/dsl/ExpressionParserTests.java
+++ b/structurizr-dsl/src/test/java/com/structurizr/dsl/ExpressionParserTests.java
@@ -55,6 +55,19 @@ class ExpressionParserTests extends AbstractTests {
     }
 
     @Test
+    void test_parseExpression_ThrowsAnException_WhenTheWildcardRelationshipIsNegated() {
+        try {
+            SystemLandscapeViewDslContext context = new SystemLandscapeViewDslContext(null);
+            context.setWorkspace(workspace);
+
+            parser.parseExpression("relationship!=*", context);
+            fail();
+        } catch (Exception e) {
+            assertEquals("The relationship \"*\" cannot be negated", e.getMessage());
+        }
+    }
+
+    @Test
     void test_parseExpression_ThrowsAnException_WhenTheRelationshipDestinationIsSpecifiedUsingShortSyntaxButDoesNotExist() {
         try {
             SystemLandscapeViewDslContext context = new SystemLandscapeViewDslContext(null);

--- a/structurizr-dsl/src/test/java/com/structurizr/dsl/ExpressionParserTests.java
+++ b/structurizr-dsl/src/test/java/com/structurizr/dsl/ExpressionParserTests.java
@@ -6,6 +6,7 @@ import com.structurizr.view.DeploymentView;
 import com.structurizr.view.SystemLandscapeView;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -137,6 +138,10 @@ class ExpressionParserTests extends AbstractTests {
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
 
+        relationships = parser.parseExpression("relationship!=a->*", context);
+        assertEquals(1, relationships.size());
+        assertTrue(relationships.contains(bToC));
+
         relationships = parser.parseExpression("a -> *", context);
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
@@ -149,6 +154,7 @@ class ExpressionParserTests extends AbstractTests {
         SoftwareSystem c = model.addSoftwareSystem("C");
         Relationship aToB = a.uses(b, "Uses");
         Relationship bToC = b.uses(c, "Uses");
+        Relationship aToC = a.uses(c, "Uses");
 
         SystemLandscapeViewDslContext context = new SystemLandscapeViewDslContext(null);
         context.setWorkspace(workspace);
@@ -162,6 +168,10 @@ class ExpressionParserTests extends AbstractTests {
         Set<ModelItem> relationships = parser.parseExpression("relationship.destination==b", context);
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
+
+        relationships = parser.parseExpression("relationship.destination!=b", context);
+        assertEquals(2, relationships.size());
+        assertTrue(relationships.containsAll(Arrays.asList(aToC, bToC)));
     }
 
     @Test
@@ -185,6 +195,10 @@ class ExpressionParserTests extends AbstractTests {
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
 
+        relationships = parser.parseExpression("relationship!=*->b", context);
+        assertEquals(1, relationships.size());
+        assertTrue(relationships.contains(bToC));
+
         relationships = parser.parseExpression("* -> b", context);
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
@@ -207,9 +221,15 @@ class ExpressionParserTests extends AbstractTests {
         elements.register("c", c);
         context.setIdentifierRegister(elements);
 
-        Set<ModelItem> relationships = parser.parseExpression("relationship.source==a && relationship.destination==b", context);
+        Set<ModelItem> relationships = parser.parseExpression("relationship.source==a && relationship.destination==b",
+                context);
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
+
+        relationships = parser.parseExpression("relationship.source!=a && relationship.destination!=b",
+                context);
+        assertEquals(1, relationships.size());
+        assertTrue(relationships.contains(bToC));
     }
 
     @Test
@@ -232,6 +252,10 @@ class ExpressionParserTests extends AbstractTests {
         Set<ModelItem> relationships = parser.parseExpression("relationship==a->b", context);
         assertEquals(1, relationships.size());
         assertTrue(relationships.contains(aToB));
+
+        relationships = parser.parseExpression("relationship!=a->b", context);
+        assertEquals(1, relationships.size());
+        assertTrue(relationships.contains(bToC));
     }
 
     @Test

--- a/structurizr-dsl/src/test/java/com/structurizr/dsl/StaticViewContentParserTests.java
+++ b/structurizr-dsl/src/test/java/com/structurizr/dsl/StaticViewContentParserTests.java
@@ -384,6 +384,56 @@ class StaticViewContentParserTests extends AbstractTests {
     }
 
     @Test
+    void test_parseExclude_RemovesAllRelationshipsExceptSpecificSourceWhenExpressionIsSpecifiedWithSource() {
+        Person user = model.addPerson("User", "Description");
+        SoftwareSystem softwareSystem1 = model.addSoftwareSystem("Software System", "Description");
+        user.uses(softwareSystem1, "Uses");
+        SoftwareSystem softwareSystem2 = model.addSoftwareSystem("Software System 2", "Description");
+        user.uses(softwareSystem2, "Uses");
+        softwareSystem1.uses(softwareSystem2, "Uses");
+
+        SystemContextView view = views.createSystemContextView(softwareSystem1, "key", "Description");
+        view.addDefaultElements();
+        SystemContextViewDslContext context = new SystemContextViewDslContext(view);
+        context.setWorkspace(workspace);
+
+        IdentifiersRegister elements = new IdentifiersRegister();
+        elements.register("user", user);
+        elements.register("softwaresystem1", softwareSystem1);
+        elements.register("softwaresystem2", softwareSystem2);
+        context.setIdentifierRegister(elements);
+
+        parser.parseExclude(context, tokens("exclude", "relationship.source!=user"));
+        assertEquals(3, view.getElements().size());
+        assertEquals(2, view.getRelationships().size());
+    }
+
+    @Test
+    void test_parseExclude_RemovesAllRelationshipsExceptSpecificSourceWhenExpressionIsSpecifiedWithWildcard() {
+        Person user = model.addPerson("User", "Description");
+        SoftwareSystem softwareSystem1 = model.addSoftwareSystem("Software System", "Description");
+        user.uses(softwareSystem1, "Uses");
+        SoftwareSystem softwareSystem2 = model.addSoftwareSystem("Software System 2", "Description");
+        user.uses(softwareSystem2, "Uses");
+        softwareSystem1.uses(softwareSystem2, "Uses");
+
+        SystemContextView view = views.createSystemContextView(softwareSystem1, "key", "Description");
+        view.addDefaultElements();
+        SystemContextViewDslContext context = new SystemContextViewDslContext(view);
+        context.setWorkspace(workspace);
+
+        IdentifiersRegister elements = new IdentifiersRegister();
+        elements.register("user", user);
+        elements.register("softwaresystem1", softwareSystem1);
+        elements.register("softwaresystem2", softwareSystem2);
+        context.setIdentifierRegister(elements);
+
+        parser.parseExclude(context, tokens("exclude", "relationship!=user->*"));
+        assertEquals(3, view.getElements().size());
+        assertEquals(2, view.getRelationships().size());
+    }
+
+    @Test
     void test_parseExclude_RemovesTheRelationshipFromAView_WhenAnExpressionIsSpecifiedWithWildcardAndDestination() {
         Person user = model.addPerson("User", "Description");
         SoftwareSystem softwareSystem = model.addSoftwareSystem("Software System", "Description");
@@ -405,6 +455,56 @@ class StaticViewContentParserTests extends AbstractTests {
 
         parser.parseExclude(context, tokens("exclude", "relationship.destination==softwareSystem"));
         assertEquals(0, view.getRelationships().size());
+    }
+
+    @Test
+    void test_parseExclude_RemovesAllRelationshipsExceptSpecificDestinationWhenExpressionIsSpecifiedWithDestination() {
+        Person user = model.addPerson("User", "Description");
+        SoftwareSystem softwareSystem1 = model.addSoftwareSystem("Software System", "Description");
+        user.uses(softwareSystem1, "Uses");
+        SoftwareSystem softwareSystem2 = model.addSoftwareSystem("Software System 2", "Description");
+        user.uses(softwareSystem2, "Uses");
+        softwareSystem1.uses(softwareSystem2, "Uses");
+
+        SystemContextView view = views.createSystemContextView(softwareSystem1, "key", "Description");
+        view.addDefaultElements();
+        SystemContextViewDslContext context = new SystemContextViewDslContext(view);
+        context.setWorkspace(workspace);
+
+        IdentifiersRegister elements = new IdentifiersRegister();
+        elements.register("user", user);
+        elements.register("softwaresystem1", softwareSystem1);
+        elements.register("softwaresystem2", softwareSystem2);
+        context.setIdentifierRegister(elements);
+
+        parser.parseExclude(context, tokens("exclude", "relationship.destination!=softwareSystem2"));
+        assertEquals(3, view.getElements().size());
+        assertEquals(2, view.getRelationships().size());
+    }
+
+    @Test
+    void test_parseExclude_RemovesAllRelationshipsExceptSpecificDestinationWhenExpressionIsSpecifiedWithWildcard() {
+        Person user = model.addPerson("User", "Description");
+        SoftwareSystem softwareSystem1 = model.addSoftwareSystem("Software System", "Description");
+        user.uses(softwareSystem1, "Uses");
+        SoftwareSystem softwareSystem2 = model.addSoftwareSystem("Software System 2", "Description");
+        user.uses(softwareSystem2, "Uses");
+        softwareSystem1.uses(softwareSystem2, "Uses");
+
+        SystemContextView view = views.createSystemContextView(softwareSystem1, "key", "Description");
+        view.addDefaultElements();
+        SystemContextViewDslContext context = new SystemContextViewDslContext(view);
+        context.setWorkspace(workspace);
+
+        IdentifiersRegister elements = new IdentifiersRegister();
+        elements.register("user", user);
+        elements.register("softwaresystem1", softwareSystem1);
+        elements.register("softwaresystem2", softwareSystem2);
+        context.setIdentifierRegister(elements);
+
+        parser.parseExclude(context, tokens("exclude", "relationship!=*->softwareSystem2"));
+        assertEquals(3, view.getElements().size());
+        assertEquals(2, view.getRelationships().size());
     }
 
     @Test


### PR DESCRIPTION
Hello,

This is my first contribution to Structurizr, and I’d like to take a moment to thank you for building this project. We use it extensively for representing our architecture, and it has been incredibly useful.

We’ve found that some of our system context diagrams can become quite large. To create smaller, more focused views, we’ve been using the following script to remove relationships that are not directly connected to the target system:

```
!script groovy {
  element = view.getSoftwareSystem();
  view.removeRelationshipsNotConnectedToElement(element);
}
```

It would be better to achieve this directly using view expressions, so I implemented support for relationship not equals expressions.

This PR introduces:
	•	`relationship.source!=`
	•	`relationship.destination!=`
	•	`relationship!=`

With these expressions, for example:

```
systemContext mySystem "MySystemContext" {
  include *
  exclude "relationship.source!=mySystem && relationship.destination!=mySystem"
}
```

one can simplify a complex diagram, such as:

![Screenshot-2025-02-18-12 45 00](https://github.com/user-attachments/assets/5a46724e-2f3a-4873-aa42-6e7002c16bc9)

or

![Screenshot-2025-02-18-13 49 44](https://github.com/user-attachments/assets/d3b8dce3-167d-429c-982b-635d9396a3b5)

into a cleaner version that only includes direct relationships to the system, removing relationships between other systems, if not relevant for the view:

![Screenshot-2025-02-18-12 45 17](https://github.com/user-attachments/assets/8c192f80-8453-4d9e-a972-5d609b7503ba)

or

![Screenshot-2025-02-18-13 48 52](https://github.com/user-attachments/assets/81394a64-739c-46d6-9d10-a432cb954a6e)


This significantly improves readability and makes it easier to understand direct dependencies for the system in question.

I hope this change can be helpful to others in improving their diagrams. I’m not very familiar with the codebase, so please let me know if I’ve missed anything. Looking forward to your feedback!